### PR TITLE
Add python version as a requirement in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Amundsen Databuilder
 Amundsen Databuilder is a [ETL](https://en.wikipedia.org/wiki/Extract,_transform,_load "ETL") framework designed to build data from Amundsen.
 
+## Requirements
+- Python = 2.7.x
+
 ## Concept
 ETL job consists of extraction of records from the source, transform records, if necessary, and load records into the sink. Amundsen Databuilder is a ETL framework for Amundsen and there are corresponding components for ETL called Extractor, Transformer, and Loader that deals with record level operation. A component called task controls all these three components.
 Job is the highest level component in Databuilder that controls task and publisher and is the one that client use to launch the ETL job.


### PR DESCRIPTION
It was not mentioned anywhere as what version of python is needed to run this project. 
Most of the amundsen libraries are using 3.6+ but this one requires 2.7.x, so it would be better to mention that in Readme.md. 
Also, the readme of amundsenfrontendlibray also mentions to install this package via python3, which would fail eventually. Will update that also. 
https://github.com/lyft/amundsenfrontendlibrary#bootstrap-a-default-version-of-amundsen-using-docker (Point # 7)