### PR TITLE
Encoding change to utf-8

### DIFF
--- a/databuilder/loader/file_system_neo4j_csv_loader.py
+++ b/databuilder/loader/file_system_neo4j_csv_loader.py
@@ -160,7 +160,7 @@ class FsNeo4jCSVLoader(Loader):
             return writer
 
         LOGGER.info('Creating file for {}'.format(key))
-        file_out = open('{}/{}.csv'.format(dir_path, file_suffix), 'w')
+        file_out = open('{}/{}.csv'.format(dir_path, file_suffix), 'w', encoding='utf-8')
 
         def file_out_close():
             # type: () -> None

--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -197,7 +197,7 @@ class Neo4jCsvPublisher(Publisher):
         :return:
         """
         tx = self._session.begin_transaction()
-        with open(node_file, 'r') as node_csv:
+        with open(node_file, 'r', encoding='utf-8') as node_csv:
             for count, node_record in enumerate(csv.DictReader(node_csv)):
                 label = node_record[NODE_LABEL_KEY]
                 # If label is seen for the first time, try creating unique index


### PR DESCRIPTION
Hi everyone, 
we have some Czech non-ascii characters (č, ž, ř ...) in table and column descriptions and we are not able to load it without this change, it works fine with this small change, so if you find it useful, please, merge it. Thanks!