### PR TITLE
unquote boolean value is_view when publish to neo4j

### DIFF
--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -5,6 +5,7 @@ from typing import Iterable, Any, Union, Iterator, Dict, Set  # noqa: F401
 from databuilder.models.neo4j_csv_serde import (
     Neo4jCsvSerializable, NODE_LABEL, NODE_KEY, RELATION_START_KEY, RELATION_END_KEY, RELATION_START_LABEL,
     RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE)
+from databuilder.publisher.neo4j_csv_publisher import UNQUOTED_SUFFIX
 
 DESCRIPTION_NODE_LABEL = 'Description'
 
@@ -68,7 +69,7 @@ class TableMetadata(Neo4jCsvSerializable):
     TABLE_NODE_LABEL = 'Table'
     TABLE_KEY_FORMAT = '{db}://{cluster}.{schema}/{tbl}'
     TABLE_NAME = 'name'
-    IS_VIEW = 'is_view'
+    IS_VIEW = 'is_view{}'.format(UNQUOTED_SUFFIX)  # bool value needs to be unquoted when publish to neo4j
 
     TABLE_DESCRIPTION = 'description'
     TABLE_DESCRIPTION_FORMAT = '{db}://{cluster}.{schema}/{tbl}/_description'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.10'
+__version__ = '1.0.11'
 
 
 setup(

--- a/tests/unit/models/test_table_metadata.py
+++ b/tests/unit/models/test_table_metadata.py
@@ -24,7 +24,8 @@ class TestTableMetadata(unittest.TestCase):
             ColumnMetadata('ds', None, 'varchar', 5)])
 
         self.expected_nodes_deduped = [
-            {'name': 'test_table1', 'KEY': 'hive://gold.test_schema1/test_table1', 'LABEL': 'Table', 'is_view': False},
+            {'name': 'test_table1', 'KEY': 'hive://gold.test_schema1/test_table1', 'LABEL': 'Table',
+             'is_view:UNQUOTED': False},
             {'description': 'test_table1', 'KEY': 'hive://gold.test_schema1/test_table1/_description',
              'LABEL': 'Description'},
             {'sort_order': 0, 'type': 'bigint', 'name': 'test_id1',


### PR DESCRIPTION
As all values pushed to neo4j by default is quoted https://github.com/lyft/amundsendatabuilder/blob/2c2b843ebd0ca08198e4940e668ea09e71335c12/databuilder/publisher/neo4j_csv_publisher.py#L333, `is_view` is changed from `bool`
 to `str` as well which is not ideal.

This PR is to add custom configuration so `is_view` can be stored in neo4j as `boolean` data type.
Example: https://github.com/lyft/amundsendatabuilder/blob/37c700d9244db8dd9b65f97519eeb986d72d0d9d/databuilder/models/table_column_usage.py#L53
https://github.com/lyft/amundsendatabuilder/blob/2c2b843ebd0ca08198e4940e668ea09e71335c12/databuilder/publisher/neo4j_csv_publisher.py#L329