### PR TITLE
gitignore dist/ as in metadataservice PR#28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,11 @@
 *.egg-info
 .*.swp
 .DS_Store
+build/
+dist/
 venv/
 venv3/
 .cache/
-build/
 .idea/
 .coverage
 .mypy_cache


### PR DESCRIPTION
Turns out `frontend` already had this: https://github.com/lyft/amundsenfrontendlibrary/blob/master/.gitignore#L25 - so we should be good on this front in all repos now