### PR TITLE
ES index written must match reader side

### DIFF
--- a/example/scripts/sample_data_loader.py
+++ b/example/scripts/sample_data_loader.py
@@ -174,7 +174,7 @@ def create_es_publisher_sample_job():
     # related to mapping type from /databuilder/publisher/elasticsearch_publisher.py#L38
     elasticsearch_new_index_key_type = 'table'
     # alias for Elasticsearch used in amundsensearchlibrary/search_service/config.py as an index
-    elasticsearch_index_alias = 'tables_alias'
+    elasticsearch_index_alias = 'table_search_index'
 
     job_config = ConfigFactory.from_dict({
         'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): neo4j_endpoint,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.11'
+__version__ = '1.0.12'
 
 
 setup(


### PR DESCRIPTION
Change this line https://github.com/lyft/amundsendatabuilder/blob/v1.0.11/example/scripts/sample_data_loader.py#L177 to match the current hardcoded value in the search service at 
https://github.com/lyft/amundsensearchlibrary/blob/v1.0.0_4/search_service/config.py#L23. This means it’s backwards compatible with existing search service Docker containers etc.

Further details originally shared on the #troubleshoot Slack channel, now here as well:

————

... but, I think it's better to start figuring out how/why your ElasticSearch is failing, you want that working anyway, and debugging it will benefit everyone by hopefully eradicating a bug. What I did to make sure hostnames, ports, networking, docker containers? etc. was set up right was this:
```
curl amundsensearch:5000/search?query_term=test
```
to mimick the frontend querying the search service - (with host/port adjusted to your settings) - it should return a JSON response. If that fails then go back and query ElasticSearch directly e.g.:
```
curl localhost:9200/_search?q=test
```
Again, yes - you guessed it, adjust host/port to your settings. If you're not getting anything useful containing `table_key` entries etc. try `curl 'localhost:9200/_cat/indices?format=json&pretty'` to see the current name of the index (it get's replaced for each example databuilder run). E.g mine right now is `tables40f17543-0435-4fcd-9b54-93482f80313a` ...with that I can check my `alias` is setup to point to the current index and what it's all called:
```
curl 'localhost:9200/_cat/aliases?format=json&pretty'
[
  {
    "alias" : "tables_alias",
    "index" : "tables40f17543-0435-4fcd-9b54-93482f80313a",
    "filter" : "-",
    "routing.index" : "-",
    "routing.search" : "-"
  }
]
```
I setup my metadata service `ELASTICSEARCH_INDEX = 'tables_alias'` ... I beleve the default settings and naming might be simplified as hinted at in the original issue thread from here on: https://github.com/lyft/amundsendatabuilder/issues/21#issuecomment-484012219 ... but, alas, that's the current state of the codebase. Hope this helps ... somewhat! (Maybe not the clearest of explanations I've ever written .. but it's Friday well EOD at work here :D)