### PR TITLE
Revert Neo4j Bolt upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ pyparsing==2.2.0
 six==1.11.0
 sqlalchemy==1.3.0
 wheel==0.31.1
-neo4j-driver==1.7.2
+neo4j-driver==1.6.0
 neotime==1.0.0
 pytz==2018.4
 antlr4-python2-runtime==4.7.1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.13'
+__version__ = '1.0.12'
 
 
 setup(
@@ -32,7 +32,7 @@ setup(
         'pyhocon==0.3.42',
         'pytest==3.6.0',
         'six',
-        'neo4j-driver==1.7.2',
+        'neo4j-driver==1.6.0',
         'antlr4-python2-runtime==4.7.1',
         'statsd==3.2.1',
         'retrying==1.3.3'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.12'
+__version__ = '1.0.14'
 
 
 setup(


### PR DESCRIPTION
version 1.7.2 is throwing exception on Neo4j publisher. Reverting. Will revisit the upgrade.