### PR TITLE
[DPTOOLS-2210] Upgrade Neo4j driver to 1.7.2

### DIFF
--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -203,7 +203,6 @@ class Neo4jCsvPublisher(Publisher):
                 # If label is seen for the first time, try creating unique index
                 if label not in self.labels:
                     tx.commit()  # Transaction needs to be committed as index update will make transaction to abort.
-                    tx.close()
                     LOGGER.info('Committed {} records'.format(count + 1))
 
                     self._try_create_index(label)
@@ -214,7 +213,6 @@ class Neo4jCsvPublisher(Publisher):
                 tx = self._execute_statement(stmt, tx, count)
 
         tx.commit()
-        tx.close()
         LOGGER.info('Committed {} records'.format(count + 1))
 
     def is_create_only_node(self, node_record):
@@ -271,7 +269,6 @@ class Neo4jCsvPublisher(Publisher):
                                              expect_result=self._confirm_rel_created)
 
         tx.commit()
-        tx.close()
         LOGGER.info('Committed {} records'.format(count + 1))
 
     def create_relationship_merge_statement(self, rel_record):
@@ -369,7 +366,6 @@ ON MATCH SET {update_prop_body}""".format(create_prop_body=create_prop_body,
 
             if count > 1 and count % self._transaction_size == 0:
                 tx.commit()
-                tx.close()
                 LOGGER.info('Committed {} records so far'.format(count))
                 return self._session.begin_transaction()
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'pyhocon==0.3.42',
         'pytest==3.6.0',
         'six',
-        'neo4j-driver==1.6.0',
+        'neo4j-driver==1.7.2',
         'antlr4-python2-runtime==4.7.1',
         'statsd==3.2.1',
         'retrying==1.3.3'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '1.0.14'
+__version__ = '1.0.15'
 
 
 setup(


### PR DESCRIPTION
- Upgrade Neo4j bolt driver from 1.6.0 to 1.7.2
- Remove `tx.close()` due to the behavior change from 1.7.2 that `tx.commit()` closes the transaction and following `tx.close()` call throws exception.