### PR TITLE
Add sample users to QuickStart 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,11 @@
 *.egg-info
 .*.swp
 .DS_Store
+build/
+dist/
 venv/
 venv3/
 .cache/
-build/
 .idea/
 .coverage
 .mypy_cache

--- a/databuilder/models/user.py
+++ b/databuilder/models/user.py
@@ -57,18 +57,18 @@ class User(Neo4jCsvSerializable):
                            then we will have a cron job to update the ex-employee nodes based on
                            the case if this timestamp hasn't been updated for two weeks.
         """
-        self.first_name = first_name.encode('utf-8')
-        self.last_name = last_name.encode('utf-8')
-        self.name = name.encode('utf-8')
+        self.first_name = first_name
+        self.last_name = last_name
+        self.name = name
 
-        self.email = email.encode('utf-8')
-        self.github_username = github_username.encode('utf-8')
+        self.email = email
+        self.github_username = github_username
         # todo: team will be a separate node once Amundsen People supports team
-        self.team_name = team_name.encode('utf-8')
-        self.manager_email = manager_email.encode('utf-8')
-        self.employee_type = employee_type.encode('utf-8')
+        self.team_name = team_name
+        self.manager_email = manager_email
+        self.employee_type = employee_type
         # this attr not available in team service, either update team service, update with FE
-        self.slack_id = slack_id.encode('utf-8')
+        self.slack_id = slack_id
         self.is_active = is_active
         self.updated_at = updated_at
 

--- a/example/sample_data/sample_user.csv
+++ b/example/sample_data/sample_user.csv
@@ -1,0 +1,4 @@
+email,first_name,last_name,name,github_username,team_name,employee_type,manager_email,slack_id
+roald.amundsen@example.org,Roald,Amundsen,"Roald Amundsen",lyft,"Team Amundsen",sailor,"phboss@example.org",ramundzn
+chrisc@example.org,Christopher,Columbus,"Christopher Columbus",ChristopherColumbusFAKE,"Team Amundsen",sailor,"phboss@example.org",chrisc
+buzz@example.org,  Buzz,       Aldrin,  "Buzz Aldrin",BuzzAldrinFAKE,                  "Team Amundsen",astronaut,"phboss@example.org",buzz


### PR DESCRIPTION

With a bit of luck this should be able to light up the mic new /users/ pages brought by lyft/amundsenfrontendlibrary#90 

Still marked as WIP because it reverts #16 encode(utf-8) change (which I don’t understand?) - can that behavior be moved - maybe to a universal transform step? If so this PR could add that commit as well.