### PR TITLE
[DPTOOLS-2299] Separate Index creation step from Node publish

### DIFF
--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -68,7 +68,6 @@ RELATION_REQUIRED_KEYS = {RELATION_START_LABEL, RELATION_START_KEY,
                           RELATION_END_LABEL, RELATION_END_KEY,
                           RELATION_TYPE, RELATION_REVERSE_TYPE}
 
-
 DEFAULT_CONFIG = ConfigFactory.from_dict({NEO4J_TRANSCATION_SIZE: 500,
                                           NEO4J_RELATIONSHIP_CREATION_CONFIRM: False,
                                           NEO4J_MAX_CONN_LIFE_TIME_SEC: 50})
@@ -99,6 +98,7 @@ class Neo4jCsvPublisher(Publisher):
 
     #TODO User UNWIND batch operation for better performance
     """
+
     def __init__(self):
         # type: () -> None
         pass
@@ -156,12 +156,8 @@ class Neo4jCsvPublisher(Publisher):
         start = time.time()
 
         LOGGER.info('Creating indices using Node files: {}'.format(self._node_files))
-        while True:
-            try:
-                node_file = next(self._node_files_iter)
-                self._create_indices(node_file=node_file)
-            except StopIteration:
-                break
+        for node_file in self._node_files:
+            self._create_indices(node_file=node_file)
 
         LOGGER.info('Publishing Node files: {}'.format(self._node_files))
         while True:
@@ -374,7 +370,7 @@ ON MATCH SET {update_prop_body}""".format(create_prop_body=create_prop_body,
                 LOGGER.debug('Executing statement: {}'.format(stmt))
 
             if six.PY2:
-                result = tx.run(unicode(stmt, errors='ignore')) # noqa
+                result = tx.run(unicode(stmt, errors='ignore'))  # noqa
             else:
                 result = tx.run(str(stmt).encode('utf-8', 'ignore'))
             if expect_result and not result.single():

--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -155,6 +155,14 @@ class Neo4jCsvPublisher(Publisher):
 
         start = time.time()
 
+        LOGGER.info('Creating indices using Node files: {}'.format(self._node_files))
+        while True:
+            try:
+                node_file = next(self._node_files_iter)
+                self._create_indices(node_file=node_file)
+            except StopIteration:
+                break
+
         LOGGER.info('Publishing Node files: {}'.format(self._node_files))
         while True:
             try:
@@ -178,6 +186,24 @@ class Neo4jCsvPublisher(Publisher):
         # type: () -> str
         return 'publisher.neo4j'
 
+    def _create_indices(self, node_file):
+        """
+        Go over the node file and try creating unique index
+        :param node_file:
+        :return:
+        """
+        # type: (str) -> None
+        LOGGER.info('Creating indices. (Existing indices will be ignored)')
+
+        with open(node_file, 'r') as node_csv:
+            for node_record in csv.DictReader(node_csv):
+                label = node_record[NODE_LABEL_KEY]
+                if label not in self.labels:
+                    self._try_create_index(label)
+                    self.labels.add(label)
+
+        LOGGER.info('Indices have been created.')
+
     def _publish_node(self, node_file):
         # type: (str) -> None
         """
@@ -199,16 +225,6 @@ class Neo4jCsvPublisher(Publisher):
         tx = self._session.begin_transaction()
         with open(node_file, 'r') as node_csv:
             for count, node_record in enumerate(csv.DictReader(node_csv)):
-                label = node_record[NODE_LABEL_KEY]
-                # If label is seen for the first time, try creating unique index
-                if label not in self.labels:
-                    tx.commit()  # Transaction needs to be committed as index update will make transaction to abort.
-                    LOGGER.info('Committed {} records'.format(count + 1))
-
-                    self._try_create_index(label)
-                    self.labels.add(label)
-                    tx = self._session.begin_transaction()
-
                 stmt = self.create_node_merge_statement(node_record=node_record)
                 tx = self._execute_statement(stmt, tx, count)
 

--- a/tests/unit/publisher/test_neo4j_csv_publisher.py
+++ b/tests/unit/publisher/test_neo4j_csv_publisher.py
@@ -51,8 +51,8 @@ class TestPublish(unittest.TestCase):
 
             self.assertEqual(mock_run.call_count, 6)
 
-            # 2 node files, 1 relation file, and 2 more commits before index creation
-            self.assertEqual(mock_commit.call_count, 5)
+            # 2 node files, 1 relation file
+            self.assertEqual(mock_commit.call_count, 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary of Changes

Separated Index creation step from node publish. Currently, index creation is done in the middle of node upsert enforcing publisher to commit the transaction. The change is to separate index creation step as a separate step and node publish step can have its own transaction.

This change would make publisher to have 2 passes against node file which turns out very negligible -- for 16k nodes, it just took less than 2 seconds.

### Tests

Exiting unit test and performed integration test.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
