### PR TITLE
Add an experimental Kafka source extractor

### DIFF
--- a/databuilder/extractor/kafka_source_extractor.py
+++ b/databuilder/extractor/kafka_source_extractor.py
@@ -1,0 +1,144 @@
+from datetime import datetime, timedelta
+import logging
+
+from confluent_kafka import Consumer, KafkaException, KafkaError
+
+from databuilder.callback.call_back import Callback
+from databuilder.extractor.base_extractor import Extractor
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class KafkaSourceExtractor(Extractor, Callback):
+    """
+    Kafka source extractor. The extractor itself is single consumer(single-threaded)
+    which could consume all the partitions given a topic or a subset of partitions.
+
+    It uses the "micro-batch" concept to ingest data from a given Kafka topic and
+    persist into downstream sink.
+    Once the publisher commit successfully, it will trigger the extractor's callback to commit the
+    consumer offset.
+    """
+    # The dict of Kafka consumer config
+    CONSUMER_CONFIG = 'consumer_config'
+    # The consumer group id. Ideally each Kafka extractor should only associate with one consumer group.
+    CONSUMER_GROUP_ID = 'group.id'
+    # We don't deserde the key of the message.
+    # CONSUMER_VALUE_DESERDE = 'value.deserializer'
+    # Each Kafka extractor should only consume one single topic. We could extend to consume more topic if needed.
+    TOPIC_NAME_LIST = 'topic_name_list'
+
+    # Time out config. It will abort from reading the Kafka topic after timeout is reached. Unit is seconds
+    CONSUMER_TOTAL_TIMEOUT = 'consumer_total_timeout'
+
+    # The timeout for consumer polling messages. Default to 1 sec
+    CONSUMER_POLL_TIMEOUT = 'consumer_poll_timeout'
+
+    RAW_VALUE_TRANSFORMER = 'raw_value_transformer'
+
+    def init(self, conf):
+        # type: (ConfigTree) -> None
+        self.conf = conf
+        # pyhocon doesn't allow dot to be in value dict,group.id -> group_id
+        self.consumer_config = conf.get_config(KafkaSourceExtractor.CONSUMER_CONFIG).\
+            as_plain_ordered_dict()
+
+        # convert group_id back to group.id
+        # noted: underscore is never used in Kafka consumer config
+        self.consumer_config = {k.replace('_', '.'): v for k, v in self.consumer_config.items()}
+
+        self.topic_names = conf.get_list(KafkaSourceExtractor.TOPIC_NAME_LIST)  # type: list
+
+        if not self.topic_names:
+            raise Exception('Kafka topic needs to be provided by the user.')
+
+        self.consumer_total_timeout = conf.get_int(KafkaSourceExtractor.CONSUMER_TOTAL_TIMEOUT,
+                                                   default=10)
+
+        self.consumer_poll_timeout = conf.get_int(KafkaSourceExtractor.CONSUMER_POLL_TIMEOUT,
+                                                  default=1)
+
+        # Transform the protoBuf message with a transformer
+        self.val_transformer = conf.get(KafkaSourceExtractor.RAW_VALUE_TRANSFORMER)
+        if self.val_transformer is None:
+            raise Exception('A message transformer should be provided.')
+
+        # Consumer init
+        try:
+            self.consumer = Consumer(self.consumer_config)
+            # TODO: to support only consume a subset of partitions.
+            self.consumer.subscribe(self.topic_names)
+        except Exception:
+            raise RuntimeError('Consumer could not start correctly!')
+
+    def extract(self):
+        # type: () -> Any
+        """
+        :return: Provides a record or None if no more to extract
+        """
+        records = self.consume()
+        for record in records:
+            try:
+                transform_record = self.val_transformer(record)
+                yield transform_record
+            except Exception as e:
+                # Has issues tranform / deserde the record. drop the record
+                LOGGER.exception(e)
+
+    def on_success(self):
+        # Type: () -> None
+        """
+        Commit the offset once get the success callback and close the consumer.
+
+        :return:
+        """
+        # set enable.auto.commit to False to avoid auto commit offset
+        if self.consumer:
+            self.consumer.commit(asynchronous=False)
+            self.consume.close()
+
+    def on_failure(self):
+        # Type: () -> None
+        if self.consumer:
+            self.consumer.close()
+
+    def consume(self):
+        # Type: () -> Any
+        """
+        Consume messages from a give list of topic
+
+        :return:
+        """
+        records = []
+        start = datetime.now()
+        try:
+            while True:
+                msg = self.consumer.poll(timeout=self.consumer_poll_timeout)
+                end = datetime.now()
+
+                # The consumer exceeds consume timeout
+                if (end - start) > timedelta(seconds=self.consumer_total_timeout):
+                    # Exceed the consume timeout
+                    break
+
+                if msg is None:
+                    continue
+
+                if msg.error():
+                    # Hit the EOF of partition
+                    if msg.error().code() == KafkaError._PARTITION_EOF:
+                        continue
+                    else:
+                        raise KafkaException(msg.error())
+                else:
+                    records.append(msg.value())
+
+        except Exception as e:
+            LOGGER.exception(e)
+        finally:
+            return records
+
+    def get_scope(self):
+        # type: () -> str
+        return 'extractor.kafka_source_extractor'

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ google-api-python-client>=1.6.0, <2.0.0dev
 google-auth-httplib2>=0.0.1
 google-auth>=1.0.0, <2.0.0dev
 httplib2~=0.9.2
+confluent-kafka==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
         'neo4j-driver==1.7.2',
         'antlr4-python2-runtime==4.7.1',
         'statsd==3.2.1',
-        'retrying==1.3.3'
+        'retrying==1.3.3',
+        'confluent-kafka==1.0.0'
     ],
     extras_require={
         ':python_version=="2.7"': ['typing>=3.6'],  # allow typehinting PY2

--- a/tests/unit/extractor/test_kafka_source_extractor.py
+++ b/tests/unit/extractor/test_kafka_source_extractor.py
@@ -1,0 +1,52 @@
+import logging
+from mock import patch, MagicMock
+import unittest
+
+from pyhocon import ConfigFactory
+
+from databuilder import Scoped
+from databuilder.extractor.kafka_source_extractor import KafkaSourceExtractor
+
+
+class TestKafkaSourceExtractor(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        logging.basicConfig(level=logging.INFO)
+        config_dict = {
+            'extractor.kafka_source_extractor.consumer_config': {'group_id': 'consumer-group',
+                                                                 'enable_auto_commit': False},
+            'extractor.kafka_source_extractor.{}'.format(KafkaSourceExtractor.RAW_VALUE_TRANSFORMER): lambda x: x,
+            'extractor.kafka_source_extractor.{}'.format(KafkaSourceExtractor.TOPIC_NAME_LIST): ['test-topic'],
+            'extractor.kafka_source_extractor.{}'.format(KafkaSourceExtractor.CONSUMER_TOTAL_TIMEOUT): 1,
+
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_consume_success(self):
+        kafka_extractor = KafkaSourceExtractor()
+        kafka_extractor.init(Scoped.get_scoped_conf(conf=self.conf,
+                                                    scope=kafka_extractor.get_scope()))
+
+        with patch.object(kafka_extractor, 'consumer') as mock_consumer:
+
+            mock_poll = MagicMock()
+            mock_poll.error.return_value = False
+            # only return once
+            mock_poll.value.side_effect = ['msg']
+            mock_consumer.poll.return_value = mock_poll
+
+            records = kafka_extractor.consume()
+            self.assertEqual(len(records), 1)
+
+    def test_consume_fail(self):
+        kafka_extractor = KafkaSourceExtractor()
+        kafka_extractor.init(Scoped.get_scoped_conf(conf=self.conf,
+                                                    scope=kafka_extractor.get_scope()))
+
+        with patch.object(kafka_extractor, 'consumer') as mock_consumer:
+            mock_poll = MagicMock()
+            mock_poll.error.return_value = True
+            mock_consumer.poll.return_value = mock_poll
+
+            records = kafka_extractor.consume()
+            self.assertEqual(len(records), 0)

--- a/tests/unit/extractor/test_kafka_source_extractor.py
+++ b/tests/unit/extractor/test_kafka_source_extractor.py
@@ -13,11 +13,12 @@ class TestKafkaSourceExtractor(unittest.TestCase):
         # type: () -> None
         logging.basicConfig(level=logging.INFO)
         config_dict = {
-            'extractor.kafka_source_extractor.consumer_config': {'group_id': 'consumer-group',
-                                                                 'enable_auto_commit': False},
-            'extractor.kafka_source_extractor.{}'.format(KafkaSourceExtractor.RAW_VALUE_TRANSFORMER): lambda x: x,
+            'extractor.kafka_source_extractor.consumer_config': {'"group.id"': 'consumer-group',
+                                                                 '"enable.auto.commit"': False},
+            'extractor.kafka_source_extractor.{}'.format(KafkaSourceExtractor.RAW_VALUE_TRANSFORMER):
+                'databuilder.transformer.base_transformer.NoopTransformer',
             'extractor.kafka_source_extractor.{}'.format(KafkaSourceExtractor.TOPIC_NAME_LIST): ['test-topic'],
-            'extractor.kafka_source_extractor.{}'.format(KafkaSourceExtractor.CONSUMER_TOTAL_TIMEOUT): 1,
+            'extractor.kafka_source_extractor.{}'.format(KafkaSourceExtractor.CONSUMER_TOTAL_TIMEOUT_SEC): 1,
 
         }
         self.conf = ConfigFactory.from_dict(config_dict)


### PR DESCRIPTION
### Summary of Changes

Solved https://github.com/lyft/amundsendatabuilder/issues/40

    Kafka source extractor. The extractor itself is single consumer(single-threaded)
    which could consume all the partitions given a topic or a subset of partitions.

    It uses the "micro-batch" concept to ingest data from a given Kafka topic and
    persist into downstream sink.
    Once the publisher commit successfully, it will trigger the extractor's callback to commit the
    consumer offset.

We are leveraging Kafka to build a push model(user push metadata to Kafka, Amundsen databuilder consumes metadata from Kafka and publish to neo4j in its own speed).

Notes: 
1. this extractor is experimental as it requires user to implement a custom transformer(like the Kafka value deserde)
2. The extractor uses single consumer ATM as we believe the bottleneck of this Kafka push model will be on the publisher side instead of the consumer side.

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
