### PR TITLE
Change USER_NODE_IS_ACTIVE to unquoted

### DIFF
--- a/databuilder/models/user.py
+++ b/databuilder/models/user.py
@@ -3,6 +3,7 @@ from typing import Union, Dict, Any  # noqa: F401
 from databuilder.models.neo4j_csv_serde import Neo4jCsvSerializable, NODE_KEY, \
     NODE_LABEL, RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
     RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+from databuilder.publisher.neo4j_csv_publisher import UNQUOTED_SUFFIX
 
 
 class User(Neo4jCsvSerializable):
@@ -21,7 +22,7 @@ class User(Neo4jCsvSerializable):
     USER_NODE_EMPLOYEE_TYPE = 'employee_type'
     USER_NODE_MANAGER_EMAIL = 'manager_email'
     USER_NODE_SLACK_ID = 'slack_id'
-    USER_NODE_IS_ACTIVE = 'is_active'
+    USER_NODE_IS_ACTIVE = 'is_active{}'.format(UNQUOTED_SUFFIX)  # bool value needs to be unquoted when publish to neo4j
     USER_NODE_UPDATED_AT = 'updated_at'
 
     USER_MANAGER_RELATION_TYPE = 'MANAGE_BY'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '1.2.2'
+__version__ = '1.2.3'
 
 
 setup(

--- a/tests/unit/models/test_table_column_usage.py
+++ b/tests/unit/models/test_table_column_usage.py
@@ -24,7 +24,7 @@ class TestTableColumnUsage(unittest.TestCase):
                      'last_name': '',
                      'full_name': '',
                      'employee_type': '',
-                     'is_active': True,
+                     'is_active:UNQUOTED': True,
                      'updated_at': 0,
                      'LABEL': 'User',
                      'slack_id': '',


### PR DESCRIPTION
### Summary of Changes

Bool value needs to be unquoted, otherwise neo4j will store the attribute as str type.

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
- [X] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
