### PR TITLE
Extend TableMetadata model to accept KV pairs attributes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ six==1.11.0
 sqlalchemy==1.3.0
 wheel==0.31.1
 neo4j-driver==1.7.2
-neotime==1.0.0
+neotime==1.7.1
 pytz==2018.4
 antlr4-python2-runtime==4.7.1
 statsd==3.2.1

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '1.2.3'
+__version__ = '1.2.4'
 
 
 setup(

--- a/tests/unit/models/test_table_metadata.py
+++ b/tests/unit/models/test_table_metadata.py
@@ -23,6 +23,14 @@ class TestTableMetadata(unittest.TestCase):
             ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
             ColumnMetadata('ds', None, 'varchar', 5)])
 
+        self.table_metadata3 = TableMetadata('hive', 'gold', 'test_schema3', 'test_table3', 'test_table3', [
+            ColumnMetadata('test_id1', 'description of test_table1', 'bigint', 0),
+            ColumnMetadata('test_id2', 'description of test_id2', 'bigint', 1),
+            ColumnMetadata('is_active', None, 'boolean', 2),
+            ColumnMetadata('source', 'description of source', 'varchar', 3),
+            ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
+            ColumnMetadata('ds', None, 'varchar', 5)], is_view=False, attr1='uri', attr2='attr2')
+
         self.expected_nodes_deduped = [
             {'name': 'test_table1', 'KEY': 'hive://gold.test_schema1/test_table1', 'LABEL': 'Table',
              'is_view:UNQUOTED': False},
@@ -131,6 +139,15 @@ class TestTableMetadata(unittest.TestCase):
             relation_row = self.table_metadata2.next_relation()
 
         self.assertEqual(self.expected_rels_deduped, actual)
+
+        node_row = self.table_metadata3.next_node()
+        t2_actual = []
+        while node_row:
+            t2_actual.append(node_row)
+            node_row = self.table_metadata3.next_node()
+
+        self.assertEqual(t2_actual[0].get('attr1'), 'uri')
+        self.assertEqual(t2_actual[0].get('attr2'), 'attr2')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary of Changes

Sometimes we would like the table metadata model to accept additional attributes(like URI, retention, owner, etc). This PR extends to model to store those additional attributes inside the node.

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
