### PR TITLE
Make confluent-kafka as optional dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ setup(
         'antlr4-python2-runtime==4.7.1',
         'statsd==3.2.1',
         'retrying==1.3.3',
-        'confluent-kafka==1.0.0'
     ],
     extras_require={
         ':python_version=="2.7"': ['typing>=3.6'],  # allow typehinting PY2
+        'kafka': ['confluent-kafka==1.0.0'],  # To use with Kafka source extractor
     },
 )


### PR DESCRIPTION
### Summary of Changes

Make confluent-kafka as optional dependency. We don't need to install confluent-kafka which brings in librdkafka if we don't use that extractor. Solved issue with https://github.com/lyft/amundsendatabuilder/issues/73

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
