### PR TITLE
Update default scope to be iterable for both py2 and py3

### DIFF
--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -34,7 +34,7 @@ class BigQueryMetadataExtractor(Extractor):
     KEY_PATH_KEY = 'key_path'
     PAGE_SIZE_KEY = 'page_size'
     FILTER_KEY = 'filter'
-    _DEFAULT_SCOPES = ('https://www.googleapis.com/auth/bigquery.readonly')
+    _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/bigquery.readonly',]
     DEFAULT_PAGE_SIZE = 300
     NUM_RETRIES = 3
     DATE_LENGTH = 8

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -34,7 +34,7 @@ class BigQueryMetadataExtractor(Extractor):
     KEY_PATH_KEY = 'key_path'
     PAGE_SIZE_KEY = 'page_size'
     FILTER_KEY = 'filter'
-    _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/bigquery.readonly',]
+    _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/bigquery.readonly', ]
     DEFAULT_PAGE_SIZE = 300
     NUM_RETRIES = 3
     DATE_LENGTH = 8

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -34,7 +34,7 @@ class BigQueryMetadataExtractor(Extractor):
     KEY_PATH_KEY = 'key_path'
     PAGE_SIZE_KEY = 'page_size'
     FILTER_KEY = 'filter'
-    _DEFAULT_SCOPES = ('https://www.googleapis.com/auth/bigquery.readonly',)
+    _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/bigquery.readonly',]
     DEFAULT_PAGE_SIZE = 300
     NUM_RETRIES = 3
     DATE_LENGTH = 8

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -34,7 +34,7 @@ class BigQueryMetadataExtractor(Extractor):
     KEY_PATH_KEY = 'key_path'
     PAGE_SIZE_KEY = 'page_size'
     FILTER_KEY = 'filter'
-    _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/bigquery.readonly',]
+    _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/bigquery.readonly']
     DEFAULT_PAGE_SIZE = 300
     NUM_RETRIES = 3
     DATE_LENGTH = 8

--- a/databuilder/extractor/bigquery_metadata_extractor.py
+++ b/databuilder/extractor/bigquery_metadata_extractor.py
@@ -34,7 +34,7 @@ class BigQueryMetadataExtractor(Extractor):
     KEY_PATH_KEY = 'key_path'
     PAGE_SIZE_KEY = 'page_size'
     FILTER_KEY = 'filter'
-    _DEFAULT_SCOPES = ['https://www.googleapis.com/auth/bigquery.readonly']
+    _DEFAULT_SCOPES = ('https://www.googleapis.com/auth/bigquery.readonly',)
     DEFAULT_PAGE_SIZE = 300
     NUM_RETRIES = 3
     DATE_LENGTH = 8


### PR DESCRIPTION
Encounter this issue( google.auth.exceptions.RefreshError: ('invalid_scope: h is not a valid audience string.', u'{\n  "error": "invalid_scope",\n  "error_description": "h is not a valid audience string."\n}')) which stackoverflow shows https://stackoverflow.com/questions/48332352/google-server-to-server-oauth-error.

### Summary of Changes

_Include a summary of changes then remove this line_

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
