### PR TITLE
Add Quickstart sample data to demo Airflow DAG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ venv/
 venv3/
 .cache/
 .idea/
+.vscode/
 .coverage
 .mypy_cache
 .pytest_cache

--- a/databuilder/models/application.py
+++ b/databuilder/models/application.py
@@ -98,7 +98,7 @@ class Application(Neo4jCsvSerializable):
     def create_relation(self):
         # type: () -> List[Dict[str, Any]]
         """
-        Create a list of relation map between watermark record with original hive table
+        Create a list of relations between application and table nodes
         :return:
         """
         results = [{

--- a/example/sample_data/sample_application.csv
+++ b/example/sample_data/sample_application.csv
@@ -1,0 +1,2 @@
+task_id,dag_id,exec_date,application_url_template
+hive.test_schema.test_table1,event_test,"2018-05-31T00:00:00","https://airflow_host.net/admin/airflow/tree?dag_id={dag_id}"


### PR DESCRIPTION
### Summary of Changes

* This is showing Airflow as the application because Amundsen already has
the Airflow icon but it could basically be any data transformation job
e.g SQL transforming from source data set(s) to a resulting data set
(Table).

  This lights up the `GENERATED BY` sidebar section visible when you navigate to http://localhost:5000/table_detail/gold/hive/test_schema/test_table1 after running 
the `python3 example/scripts/sample_data_loader.py` Quickstart loader.

  At the same time this PR serves as an example of how to use the simpler of 
the Amundsen data builder `model/` classes (e.g. I think the table_stats one
would be pretty similar).

* A minor addition of a commented out line you can enable to get INFO level 
logging when running the Quickstart example data loader script.

### Tests

As usual for example code branch no tests

### Documentation

No additional docco.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
