### PR TITLE
Replace Threadpool to Pool on SqlToTblColUsageTransformer

### DIFF
--- a/databuilder/transformer/sql_to_table_col_usage_transformer.py
+++ b/databuilder/transformer/sql_to_table_col_usage_transformer.py
@@ -1,5 +1,5 @@
 import logging
-from multiprocessing.pool import ThreadPool, TimeoutError
+from multiprocessing.pool import Pool, TimeoutError
 
 from pyhocon import ConfigTree  # noqa: F401
 from typing import Any, Optional, List, Iterable  # noqa: F401
@@ -44,7 +44,7 @@ class SqlToTblColUsageTransformer(Transformer):
         self._sql_stmt_attr = conf.get_string(SqlToTblColUsageTransformer.SQL_STATEMENT_ATTRIBUTE_NAME)
         self._user_email_attr = conf.get_string(SqlToTblColUsageTransformer.USER_EMAIL_ATTRIBUTE_NAME)
         self._tbl_to_schema_mapping = self._create_schema_by_table_mapping()
-        self._worker_pool = ThreadPool(processes=1)
+        self._worker_pool = Pool(processes=1)
         self._time_out_sec = conf.get_int(SqlToTblColUsageTransformer.COLUMN_EXTRACTION_TIMEOUT_SEC, 10)
         LOGGER.info('Column extraction timeout: {} seconds'.format(self._time_out_sec))
         self._log_all_extraction_failures = conf.get_bool(SqlToTblColUsageTransformer.LOG_ALL_EXTRACTION_FAILURES,

--- a/databuilder/transformer/sql_to_table_col_usage_transformer.py
+++ b/databuilder/transformer/sql_to_table_col_usage_transformer.py
@@ -1,4 +1,8 @@
-import copy_reg
+try:
+    import copy_reg
+except Exception:
+    import copyreg as copy_reg
+
 import logging
 import types
 from multiprocessing.pool import Pool, TimeoutError
@@ -13,11 +17,13 @@ from databuilder.sql_parser.usage.column import OrTable, Table  # noqa: F401
 from databuilder.sql_parser.usage.presto.column_usage_provider import ColumnUsageProvider
 from databuilder.transformer.base_transformer import Transformer
 
-
 LOGGER = logging.getLogger(__name__)
 
 
 def _pickle_method(m):
+    """
+    Pool needs to pickle method in order to pass it to separate process. This method is to define how to pickle method.
+    """
     if m.im_self is None:
         return getattr, (m.im_class, m.im_func.func_name)
     else:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '1.3.5'
+__version__ = '1.3.6'
 
 
 setup(


### PR DESCRIPTION
### Summary of Changes

Currently `SqlToTblColUsageTransformer` uses Threadpool just to perform timeout when ANTLR tree hits infinite loop. It turned out that Python's Threadpool internally didn't implement terminate() method and cannot be timedout. Therefore, replaced it with Pool which uses process. 

I had a concern on Pool in performance as it needs to communicate with different process but the performance difference was negligible.

### Tests

Integration test done.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
