### PR TITLE
Add a flag to allow to specify database for pg extractor

### DIFF
--- a/databuilder/extractor/postgres_metadata_extractor.py
+++ b/databuilder/extractor/postgres_metadata_extractor.py
@@ -41,6 +41,7 @@ class PostgresMetadataExtractor(Extractor):
     WHERE_CLAUSE_SUFFIX_KEY = 'where_clause_suffix'
     CLUSTER_KEY = 'cluster_key'
     USE_CATALOG_AS_CLUSTER_NAME = 'use_catalog_as_cluster_name'
+    DATABASE_KEY = 'database_key'
 
     # Default values
     DEFAULT_CLUSTER_NAME = 'master'
@@ -58,6 +59,9 @@ class PostgresMetadataExtractor(Extractor):
             cluster_source = "c.table_catalog"
         else:
             cluster_source = "'{}'".format(self._cluster)
+
+        self._database = conf.get_string(PostgresMetadataExtractor.DATABASE_KEY,
+                                         default='postgres').encode('utf-8', 'ignore')
 
         self.sql_stmt = PostgresMetadataExtractor.SQL_STATEMENT.format(
             where_clause_suffix=conf.get_string(PostgresMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY),
@@ -100,7 +104,7 @@ class PostgresMetadataExtractor(Extractor):
                 columns.append(ColumnMetadata(row['col_name'], row['col_description'],
                                               row['col_type'], row['col_sort_order']))
 
-            yield TableMetadata('postgres', last_row['cluster'],
+            yield TableMetadata(self._database, last_row['cluster'],
                                 last_row['schema_name'],
                                 last_row['name'],
                                 last_row['description'],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = '1.3.6'
+__version__ = '1.3.7'
 
 
 setup(

--- a/tests/unit/extractor/test_postgres_metadata_extractor.py
+++ b/tests/unit/extractor/test_postgres_metadata_extractor.py
@@ -21,7 +21,9 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             'extractor.postgres_metadata.{}'.format(PostgresMetadataExtractor.CLUSTER_KEY):
             'MY_CLUSTER',
             'extractor.postgres_metadata.{}'.format(PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME):
-            False
+            False,
+            'extractor.postgres_metadata.{}'.format(PostgresMetadataExtractor.DATABASE_KEY):
+            'postgres'
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -94,6 +96,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
                                       ColumnMetadata('source', 'description of source', 'varchar', 3),
                                       ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
                                       ColumnMetadata('ds', None, 'varchar', 5)])
+
             self.assertEqual(expected.__repr__(), actual.__repr__())
             self.assertIsNone(extractor.extract())
 


### PR DESCRIPTION
### Summary of Changes

Provide a config to allow user specify database for pg extractor. In that case, we could reuse the extractor for redshift tables.

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
