### PR TITLE
Update postgres_metadata_extractor.py

### DIFF
--- a/databuilder/extractor/postgres_metadata_extractor.py
+++ b/databuilder/extractor/postgres_metadata_extractor.py
@@ -61,7 +61,7 @@ class PostgresMetadataExtractor(Extractor):
             cluster_source = "'{}'".format(self._cluster)
 
         self._database = conf.get_string(PostgresMetadataExtractor.DATABASE_KEY,
-                                         default='postgres').encode('utf-8', 'ignore')
+                                         default='postgres')
 
         self.sql_stmt = PostgresMetadataExtractor.SQL_STATEMENT.format(
             where_clause_suffix=conf.get_string(PostgresMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY),


### PR DESCRIPTION
With Python3, it's mandatory to remove the `.encode('utf-8','ignore')`. If you don't do this change it doesn't work, because your database get's an extra `'b`in the name, like: 
```
"MERGE (node:Table {key: 'b'postgres'://airflow.public/alembic_version'})"
```
This because the `.encode('utf-8','ignore')` returns a byte.

### Summary of Changes

Only removed the: `.encode('utf-8','ignore')`

### Tests

Was able to run the DAG: postgres_sample_dag.py based an a postgres database. Also tested with a table and column containing accents like: 'élève'.
Airflow running Python version 3.6.

### Documentation

Without this change it doesn't worked.

![image](https://user-images.githubusercontent.com/13253805/61242880-15b1c800-a747-11e9-82f5-e4f616281036.png)

