### PR TITLE
Check for a valid string on the regex transformer.

### DIFF
--- a/databuilder/transformer/regex_str_replace_transformer.py
+++ b/databuilder/transformer/regex_str_replace_transformer.py
@@ -18,6 +18,8 @@ class RegexStrReplaceTransformer(Transformer):
     """
     Generic string replacement transformer using REGEX.
     User can pass list of tuples where tuple contains regex and replacement pair.
+
+    Any non-string values will be ignored.
     """
     def init(self, conf):
         # type: (ConfigTree) -> None
@@ -27,7 +29,12 @@ class RegexStrReplaceTransformer(Transformer):
     def transform(self, record):
         # type: (Any) -> Any
         val = getattr(record, self._attribute_name)
-        if six.PY2 and isinstance(val, six.text_type):
+
+        if val is None or not isinstance(val, six.string_types):
+            return record
+
+        # Encode unicode string
+        if six.PY2:
             val = val.encode('utf-8', 'ignore')
 
         for regex_replace_tuple in self._regex_replace_tuples:

--- a/tests/unit/transformer/test_regex_str_replace_transformer.py
+++ b/tests/unit/transformer/test_regex_str_replace_transformer.py
@@ -9,6 +9,33 @@ class TestRegexReplacement(unittest.TestCase):
 
     def test(self):
         # type: () -> None
+        transformer = self._default_test_transformer()
+
+        foo = Foo('abc')
+        actual = transformer.transform(foo)
+
+        self.assertEqual('bba', actual.val)
+
+    def test_numeric_val(self):
+        # type: () -> None
+        transformer = self._default_test_transformer()
+
+        foo = Foo(6)
+        actual = transformer.transform(foo)
+
+        self.assertEqual(6, actual.val)
+
+    def test_none_val(self):
+        # type: () -> None
+        transformer = self._default_test_transformer()
+
+        foo = Foo(None)
+        actual = transformer.transform(foo)
+
+        self.assertEqual(None, actual.val)
+
+    def _default_test_transformer(self):
+        # type: () -> RegexStrReplaceTransformer
         config = ConfigFactory.from_dict({
             'regex_replace_tuple_list': [('a', 'b'), ('c', 'a')],
             'attribute_name': 'val'
@@ -17,10 +44,7 @@ class TestRegexReplacement(unittest.TestCase):
         transformer = RegexStrReplaceTransformer()
         transformer.init(config)
 
-        foo = Foo('abc')
-        actual = transformer.transform(foo)
-
-        self.assertEqual('bba', actual.val)
+        return transformer
 
 
 class Foo(object):


### PR DESCRIPTION
### Summary of Changes

The current regex string transformer will fail if a None value is provided.  This makes it difficult to use for data that is optional.  In particular, we weren't able to use it for column descriptions because not all columns have descriptions.

I added a check for None and exited early if the value matched None.  In addition, I added a check to make sure the value was not numerical.

### Tests

I added unit tests test to make sure that numeric and None values are ignored for the regex transformer.

I confirmed that the numeric change would not cause an unintended regression by running the unit test and confirming it caused an AttributeError on the val.replace method call. 

### Documentation

I made a change to python doc that outlined the new rules that ignored.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
