### PR TITLE
Set neo4j publisher CSV field_size_limit to max

### DIFF
--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -1,6 +1,7 @@
 import copy
 import csv
 import logging
+import sys
 import time
 from os import listdir
 from os.path import isfile, join
@@ -15,6 +16,16 @@ from typing import Set, List  # noqa: F401
 from databuilder.publisher.base_publisher import Publisher
 from databuilder.publisher.neo4j_preprocessor import NoopRelationPreprocessor
 
+
+# Setting field_size_limit to solve the error below
+# _csv.Error: field larger than field limit (131072)
+maxInt = sys.maxsize
+while True:
+    try:
+        csv.field_size_limit(maxInt)
+        break
+    except OverflowError:
+        maxInt = int(maxInt/10)
 
 # Config keys
 # A directory that contains CSV files for nodes


### PR DESCRIPTION
### Summary of Changes

This PR should solve `_csv.Error: field larger than field limit (131072)` in publisher. The error is normally thrown if there is really long field in csv file.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
