### PR TITLE
Add sample high/low watermark data to quick start (#62)

### DIFF
--- a/databuilder/models/hive_watermark.py
+++ b/databuilder/models/hive_watermark.py
@@ -1,21 +1,15 @@
-from typing import Any, Dict, List, Union  # noqa: F401
+from databuilder.models.watermark import Watermark
+import warnings
+warnings.warn("HiveWatermark class is deprecated. Use Watermark instead",
+              DeprecationWarning, stacklevel=2)
 
-from databuilder.models.neo4j_csv_serde import Neo4jCsvSerializable, NODE_KEY, \
-    NODE_LABEL, RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
-    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
 
-
-class HiveWatermark(Neo4jCsvSerializable):
+class HiveWatermark(Watermark):
     # type: (...) -> None
     """
     Hive table watermark result model.
-    Each instance represents one row of hive watermark result.
+    Each instance represents one row of hive table watermark result.
     """
-    LABEL = 'Watermark'
-    KEY_FORMAT = 'hive://{cluster}.{schema}' \
-                 '/{table}/{part_type}/'
-    WATERMARK_TABLE_RELATION_TYPE = 'BELONG_TO_TABLE'
-    TABLE_WATERMARK_RELATION_TYPE = 'WATERMARK'
 
     def __init__(self,
                  create_time,  # type: str
@@ -26,80 +20,11 @@ class HiveWatermark(Neo4jCsvSerializable):
                  cluster='gold',  # type: str
                  ):
         # type: (...) -> None
-        self.create_time = create_time
-        self.schema = schema_name.lower()
-        self.table = table_name.lower()
-        self.parts = []  # type: list
-
-        if '=' not in part_name:
-            raise Exception('Only partition table has high watermark')
-
-        # currently we don't consider nested partitions
-        idx = part_name.find('=')
-        name, value = part_name.lower()[:idx], part_name.lower()[idx + 1:]
-        self.parts = [(name, value)]
-        self.part_type = part_type.lower()
-        self.cluster = cluster.lower()
-        self._node_iter = iter(self.create_nodes())
-        self._relation_iter = iter(self.create_relation())
-
-    def create_next_node(self):
-        # type: (...) -> Union[Dict[str, Any], None]
-        # return the string representation of the data
-        try:
-            return next(self._node_iter)
-        except StopIteration:
-            return None
-
-    def create_next_relation(self):
-        # type: (...) -> Union[Dict[str, Any], None]
-        try:
-            return next(self._relation_iter)
-        except StopIteration:
-            return None
-
-    def get_watermark_model_key(self):
-        # type: (...) -> str
-        return HiveWatermark.KEY_FORMAT.format(cluster=self.cluster,
-                                               schema=self.schema,
-                                               table=self.table,
-                                               part_type=self.part_type)
-
-    def get_metadata_model_key(self):
-        # type: (...) -> str
-        return 'hive://{cluster}.{schema}/{table}'.format(cluster=self.cluster,
-                                                          schema=self.schema,
-                                                          table=self.table)
-
-    def create_nodes(self):
-        # type: () -> List[Dict[str, Any]]
-        """
-        Create a list of Neo4j node records
-        :return:
-        """
-        results = []
-        for part in self.parts:
-            results.append({
-                NODE_KEY: self.get_watermark_model_key(),
-                NODE_LABEL: HiveWatermark.LABEL,
-                'partition_key': part[0],
-                'partition_value': part[1],
-                'create_time': self.create_time
-            })
-        return results
-
-    def create_relation(self):
-        # type: () -> List[Dict[str, Any]]
-        """
-        Create a list of relation map between watermark record with original hive table
-        :return:
-        """
-        results = [{
-            RELATION_START_KEY: self.get_watermark_model_key(),
-            RELATION_START_LABEL: HiveWatermark.LABEL,
-            RELATION_END_KEY: self.get_metadata_model_key(),
-            RELATION_END_LABEL: 'Table',
-            RELATION_TYPE: HiveWatermark.WATERMARK_TABLE_RELATION_TYPE,
-            RELATION_REVERSE_TYPE: HiveWatermark.TABLE_WATERMARK_RELATION_TYPE
-        }]
-        return results
+        super(HiveWatermark, self).__init__(create_time=create_time,
+                                            database='hive',
+                                            schema_name=schema_name,
+                                            table_name=table_name,
+                                            part_name=part_name,
+                                            part_type=part_type,
+                                            cluster=cluster,
+                                            )

--- a/databuilder/models/watermark.py
+++ b/databuilder/models/watermark.py
@@ -1,0 +1,109 @@
+from typing import Any, Dict, List, Union  # noqa: F401
+
+from databuilder.models.neo4j_csv_serde import Neo4jCsvSerializable, NODE_KEY, \
+    NODE_LABEL, RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
+    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+
+
+class Watermark(Neo4jCsvSerializable):
+    # type: (...) -> None
+    """
+    Table watermark result model.
+    Each instance represents one row of table watermark result.
+    """
+    LABEL = 'Watermark'
+    KEY_FORMAT = '{database}://{cluster}.{schema}' \
+                 '/{table}/{part_type}/'
+    WATERMARK_TABLE_RELATION_TYPE = 'BELONG_TO_TABLE'
+    TABLE_WATERMARK_RELATION_TYPE = 'WATERMARK'
+
+    def __init__(self,
+                 create_time,  # type: str
+                 database,  # type: str
+                 schema_name,  # type: str
+                 table_name,  # type: str
+                 part_name,  # type: str
+                 part_type='high_watermark',  # type: str
+                 cluster='gold',  # type: str
+                 ):
+        # type: (...) -> None
+        self.create_time = create_time
+        self.database = database.lower()
+        self.schema = schema_name.lower()
+        self.table = table_name.lower()
+        self.parts = []  # type: list
+
+        if '=' not in part_name:
+            raise Exception('Only partition table has high watermark')
+
+        # currently we don't consider nested partitions
+        idx = part_name.find('=')
+        name, value = part_name.lower()[:idx], part_name.lower()[idx + 1:]
+        self.parts = [(name, value)]
+        self.part_type = part_type.lower()
+        self.cluster = cluster.lower()
+        self._node_iter = iter(self.create_nodes())
+        self._relation_iter = iter(self.create_relation())
+
+    def create_next_node(self):
+        # type: (...) -> Union[Dict[str, Any], None]
+        # return the string representation of the data
+        try:
+            return next(self._node_iter)
+        except StopIteration:
+            return None
+
+    def create_next_relation(self):
+        # type: (...) -> Union[Dict[str, Any], None]
+        try:
+            return next(self._relation_iter)
+        except StopIteration:
+            return None
+
+    def get_watermark_model_key(self):
+        # type: (...) -> str
+        return Watermark.KEY_FORMAT.format(database=self.database,
+                                           cluster=self.cluster,
+                                           schema=self.schema,
+                                           table=self.table,
+                                           part_type=self.part_type)
+
+    def get_metadata_model_key(self):
+        # type: (...) -> str
+        return '{database}://{cluster}.{schema}/{table}'.format(database=self.database,
+                                                                cluster=self.cluster,
+                                                                schema=self.schema,
+                                                                table=self.table)
+
+    def create_nodes(self):
+        # type: () -> List[Dict[str, Any]]
+        """
+        Create a list of Neo4j node records
+        :return:
+        """
+        results = []
+        for part in self.parts:
+            results.append({
+                NODE_KEY: self.get_watermark_model_key(),
+                NODE_LABEL: Watermark.LABEL,
+                'partition_key': part[0],
+                'partition_value': part[1],
+                'create_time': self.create_time
+            })
+        return results
+
+    def create_relation(self):
+        # type: () -> List[Dict[str, Any]]
+        """
+        Create a list of relation map between watermark record with original table
+        :return:
+        """
+        results = [{
+            RELATION_START_KEY: self.get_watermark_model_key(),
+            RELATION_START_LABEL: Watermark.LABEL,
+            RELATION_END_KEY: self.get_metadata_model_key(),
+            RELATION_END_LABEL: 'Table',
+            RELATION_TYPE: Watermark.WATERMARK_TABLE_RELATION_TYPE,
+            RELATION_REVERSE_TYPE: Watermark.TABLE_WATERMARK_RELATION_TYPE
+        }]
+        return results

--- a/example/sample_data/sample_watermark.csv
+++ b/example/sample_data/sample_watermark.csv
@@ -1,0 +1,5 @@
+create_time,database,schema_name,table_name,part_name,part_type,cluster
+2019-10-01T12:13:14,hive,test_schema,test_table1,col3=2017-04-22/col4=0,LOW_WATERMARK,gold
+2019-10-01T12:13:14,hive,test_schema,test_table1,col3=2019-09-30/col4=11,HIGH_WATERMARK,gold
+2019-10-01T12:13:14,dynamo,test_schema,test_table2,col3=2018-01-01,LOW_WATERMARK,gold
+2019-10-01T12:13:14,dynamo,test_schema,test_table2,col3=2019-10-01,HIGH_WATERMARK,gold

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '1.4.6'
+__version__ = '1.4.7'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/tests/unit/models/test_watermark.py
+++ b/tests/unit/models/test_watermark.py
@@ -1,12 +1,13 @@
 import unittest
-from databuilder.models.hive_watermark import HiveWatermark
+from databuilder.models.watermark import Watermark
 
 from databuilder.models.neo4j_csv_serde import NODE_KEY, \
     NODE_LABEL, RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
     RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
 
+
 CREATE_TIME = '2017-09-18T00:00:00'
-DATABASE = 'HIVE'
+DATABASE = 'DYNAMO'
 SCHEMA = 'BASE'
 TABLE = 'TEST'
 NESTED_PART = 'ds=2017-09-18/feature_id=9'
@@ -14,17 +15,18 @@ CLUSTER = 'DEFAULT'
 PART_TYPE = 'LOW_WATERMARK'
 
 
-class TestHiveWatermark(unittest.TestCase):
+class TestWatermark(unittest.TestCase):
 
     def setUp(self):
         # type: () -> None
-        super(TestHiveWatermark, self).setUp()
-        self.watermark = HiveWatermark(create_time='2017-09-18T00:00:00',
-                                       schema_name=SCHEMA,
-                                       table_name=TABLE,
-                                       cluster=CLUSTER,
-                                       part_type=PART_TYPE,
-                                       part_name=NESTED_PART)
+        super(TestWatermark, self).setUp()
+        self.watermark = Watermark(create_time='2017-09-18T00:00:00',
+                                   database=DATABASE,
+                                   schema_name=SCHEMA,
+                                   table_name=TABLE,
+                                   cluster=CLUSTER,
+                                   part_type=PART_TYPE,
+                                   part_name=NESTED_PART)
 
         self.expected_node_result = {
             NODE_KEY: '{database}://{cluster}.{schema}/{table}/{part_type}/'


### PR DESCRIPTION
### Summary of Changes

Sample quickstart data enriched with table watermarks info (oldest & latest partitions).
Also HiveWatermark class redesigned to handle any DB type watermarks.

### Tests

No new tests. Existing tests for watermarks have been updated.

### Documentation

No new documentation.

Displayed watermark data example:
![image](https://user-images.githubusercontent.com/2134660/65869743-09272e00-e38c-11e9-82e1-7cacf4e71fe7.png)
