### PR TITLE
Allow credential pass from conf variable for BQ extractor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '1.4.8'
+__version__ = '1.4.9'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')


### PR DESCRIPTION
Currently the key path may not be available as a file, we should support the case if the credential is pass as a string.

This is supported per gcp doc(https://google-auth.readthedocs.io/en/latest/reference/google.oauth2.service_account.html).