### PR TITLE
BigQuery Usage Extractor: Guard against log entry pages not containing 'entries' key

### DIFF
--- a/databuilder/extractor/bigquery_usage_extractor.py
+++ b/databuilder/extractor/bigquery_usage_extractor.py
@@ -158,7 +158,8 @@ class BigQueryTableUsageExtractor(Extractor):
         response = self.logging_service.entries().list(body=body).execute(
             num_retries=BigQueryTableUsageExtractor.NUM_RETRIES)
         while response:
-            yield response
+            if 'entries' in response:
+                yield response
 
             try:
                 if 'nextPageToken' in response:


### PR DESCRIPTION
### Summary of Changes

In practice, when requesting logs going back more than a few days, the
StackDriver API sometimes responds with an empty page with a next page
cursor. After polling the next page a few times you eventually start
getting entries. The empty pages have no `entries` key, which previously
resulted in a KeyError.

This change allows the extractor to continue polling instead of blowing up.

### Tests

Added a simple test with a mocked out response with no entries that fails with `KeyError` if the guard clause is not present.

### Documentation

No doc changes required.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
