### PR TITLE
Postgres Metadata Extractor logger fixed

### DIFF
--- a/databuilder/extractor/postgres_metadata_extractor.py
+++ b/databuilder/extractor/postgres_metadata_extractor.py
@@ -72,11 +72,13 @@ class PostgresMetadataExtractor(Extractor):
             cluster_source=cluster_source
         )
 
-        LOGGER.info('SQL for postgres metadata: {}'.format(self.sql_stmt))
-
         self._alchemy_extractor = SQLAlchemyExtractor()
         sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\
             .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
+
+        self.sql_stmt = sql_alch_conf.get_string(SQLAlchemyExtractor.EXTRACT_SQL)
+
+        LOGGER.info('SQL for postgres metadata: {}'.format(self.sql_stmt))
 
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter = None  # type: Union[None, Iterator]


### PR DESCRIPTION
### Summary of Changes

Since the Postgres Metadata Extractor logged the sql statement right after formatting it with the `cluster_source` and `where_clause_suffix` if we override the sql statement through `'extractor.postgres_metadata.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.EXTRACT_SQL)` it would work but it would log the wrong statement

### Tests

I didn't add any tests since testing what the logger is printing is not that simple (or maybe it is) and it wouldn't be something valuable to test (always open to discuss it)