### PR TITLE
Add Redshift spectrum metadata extractor based on postgres extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,28 @@ job = DefaultJob(
 job.launch()
 ```
 
+#### [RedshiftSpectrumMetadataExtractor](https://github.com/lyft/amundsendatabuilder/blob/master/databuilder/extractor/redshift_spectrum_metadata_extractor.py "RedshiftSpectrumMetadataExtractor")
+An extractor that extracts table and column metadata including database, schema, table name and column name from a Redshift database for Redshift Spectrum (external) tables.
+Please note that the table and column descriptions are empty by default.
+
+By default, `spectrum` is used as the cluster name and database name.
+Use `CLUSTER_KEY`/`DATABASE_KEY` to what you wish to use as the cluster and database names respectively.
+
+The `where_clause_suffix` below should define which schemas you'd like to query (see [the sample script](https://github.com/lyft/amundsendatabuilder/blob/master/example/scripts/sample_redshift_spectrum_loader.py) for an example).
+
+```python
+job_config = ConfigFactory.from_dict({
+	'extractor.redshift_spectrum_metadata.{}'.format(RedshiftSpectrumMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY): where_clause_suffix,
+    'extractor.redshift_spectrum_metadata.{}'.format(RedshiftSpectrumMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME): True,
+	'extractor.redshift_spectrum_metadata.extractor.sqlalchemy.{}'.format(RedshiftSpectrumMetadataExtractor.CONN_STRING): connection_string()})
+job = DefaultJob(
+	conf=job_config,
+	task=DefaultTask(
+		extractor=RedshiftSpectrumMetadataExtractor(),
+		loader=AnyLoader()))
+job.launch()
+```
+
 #### [TblColUsgAggExtractor](https://github.com/lyft/amundsendatabuilder/blob/master/databuilder/extractor/table_column_usage_aggregate_extractor.py "TblColUsgAggExtractor")
 An extractor that extracts table usage from SQL statements. It accept any extractor  that extracts row from source that has SQL audit log. Once SQL statement is extracted, it uses [ANTLR](https://www.antlr.org/ "ANTLR") to parse and get tables and columns that it reads from. Also, it aggregates usage based on table and user. (Column level aggregation is not there yet.)
 

--- a/databuilder/extractor/redshift_spectrum_metadata_extractor.py
+++ b/databuilder/extractor/redshift_spectrum_metadata_extractor.py
@@ -1,0 +1,136 @@
+import logging
+import six
+from collections import namedtuple
+
+from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
+from typing import Iterator, Union, Dict, Any  # noqa: F401
+
+from databuilder import Scoped
+from databuilder.extractor.base_extractor import Extractor
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from itertools import groupby
+
+
+TableKey = namedtuple('TableKey', ['schema_name', 'table_name'])
+
+LOGGER = logging.getLogger(__name__)
+
+
+class RedshiftSpectrumMetadataExtractor(Extractor):
+    """
+    Extracts Postgres table and column metadata from underlying meta store database using SQLAlchemyExtractor
+    """
+    # SELECT statement from postgres information_schema to extract table and column metadata
+    SQL_STATEMENT = """
+    SELECT 
+       '{cluster_source}'     as cluster,
+       schemaname           as schema_name,
+       tablename            as name,
+       ''                   as description,
+       columnname           as col_name,
+       external_type        as col_type,
+       ''                   as col_description,
+       columnnum            as col_sort_order
+    FROM pg_catalog.svv_external_columns
+    {where_clause_suffix}
+    ORDER BY cluster, schema_name, name, col_sort_order;
+    """
+
+    # CONFIG KEYS
+    WHERE_CLAUSE_SUFFIX_KEY = 'where_clause_suffix'
+    CLUSTER_KEY = 'cluster_key'
+    DATABASE_KEY = 'database_key'
+
+    # Default values
+    DEFAULT_CLUSTER_NAME = 'spectrum'
+
+    DEFAULT_CONFIG = ConfigFactory.from_dict(
+        {
+            WHERE_CLAUSE_SUFFIX_KEY: ' ',
+            CLUSTER_KEY: DEFAULT_CLUSTER_NAME
+        }
+    )
+
+    def init(self, conf):
+        # type: (ConfigTree) -> None
+        conf = conf.with_fallback(RedshiftSpectrumMetadataExtractor.DEFAULT_CONFIG)
+        self._cluster = '{}'.format(conf.get_string(RedshiftSpectrumMetadataExtractor.CLUSTER_KEY))
+
+        database = conf.get_string(RedshiftSpectrumMetadataExtractor.DATABASE_KEY, default='spectrum')
+        if six.PY2 and isinstance(database, six.text_type):
+            database = database.encode('utf-8', 'ignore')
+
+        self._database = database
+
+        self.sql_stmt = RedshiftSpectrumMetadataExtractor.SQL_STATEMENT.format(
+            where_clause_suffix=conf.get_string(RedshiftSpectrumMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY),
+            cluster_source=self._cluster
+        )
+
+        self._alchemy_extractor = SQLAlchemyExtractor()
+        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\
+            .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
+
+        self.sql_stmt = sql_alch_conf.get_string(SQLAlchemyExtractor.EXTRACT_SQL)
+
+        LOGGER.info('SQL for postgres metadata: {}'.format(self.sql_stmt))
+
+        self._alchemy_extractor.init(sql_alch_conf)
+        self._extract_iter = None  # type: Union[None, Iterator]
+
+    def extract(self):
+        # type: () -> Union[TableMetadata, None]
+        if not self._extract_iter:
+            self._extract_iter = self._get_extract_iter()
+        try:
+            return next(self._extract_iter)
+        except StopIteration:
+            return None
+
+    def get_scope(self):
+        # type: () -> str
+        return 'extractor.redshift_spectrum_metadata'
+
+    def _get_extract_iter(self):
+        # type: () -> Iterator[TableMetadata]
+        """
+        Using itertools.groupby and raw level iterator, it groups to table and yields TableMetadata
+        :return:
+        """
+        for key, group in groupby(self._get_raw_extract_iter(), self._get_table_key):
+            columns = []
+
+            for row in group:
+                last_row = row
+                columns.append(ColumnMetadata(row['col_name'], row['col_description'],
+                                              row['col_type'], row['col_sort_order']))
+
+            yield TableMetadata(self._database, last_row['cluster'],
+                                last_row['schema_name'],
+                                last_row['name'],
+                                last_row['description'],
+                                columns)
+
+    def _get_raw_extract_iter(self):
+        # type: () -> Iterator[Dict[str, Any]]
+        """
+        Provides iterator of result row from SQLAlchemy extractor
+        :return:
+        """
+        row = self._alchemy_extractor.extract()
+        while row:
+            yield row
+            row = self._alchemy_extractor.extract()
+
+    def _get_table_key(self, row):
+        # type: (Dict[str, Any]) -> Union[TableKey, None]
+        """
+        Table key consists of schema and table name
+        :param row:
+        :return:
+        """
+        if row:
+            return TableKey(schema_name=row['schema_name'], table_name=row['name'])
+
+        return None

--- a/example/scripts/sample_redshift_spectrum_loader.py
+++ b/example/scripts/sample_redshift_spectrum_loader.py
@@ -1,0 +1,131 @@
+import textwrap
+import uuid
+
+from elasticsearch import Elasticsearch
+from pyhocon import ConfigFactory
+from databuilder.extractor.neo4j_search_data_extractor import Neo4jSearchDataExtractor
+from databuilder.extractor.redshift_spectrum_metadata_extractor import RedshiftSpectrumMetadataExtractor
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
+from databuilder.extractor.neo4j_extractor import Neo4jExtractor
+from databuilder.job.job import DefaultJob
+from databuilder.loader.file_system_elasticsearch_json_loader import FSElasticsearchJSONLoader
+from databuilder.loader.file_system_neo4j_csv_loader import FsNeo4jCSVLoader
+from databuilder.publisher import neo4j_csv_publisher
+from databuilder.publisher.neo4j_csv_publisher import Neo4jCsvPublisher
+from databuilder.task.task import DefaultTask
+from databuilder.transformer.base_transformer import NoopTransformer
+
+# NEO4J cluster endpoints
+NEO4J_ENDPOINT = 'bolt://localhost:7687'
+
+neo4j_endpoint = NEO4J_ENDPOINT
+
+neo4j_user = 'neo4j'
+neo4j_password = 'test'
+
+es = Elasticsearch([
+    {'host': 'localhost'},
+])
+
+SUPPORTED_SCHEMAS = ['spectrum']
+SUPPORTED_SCHEMA_SQL_IN_CLAUSE = "('{schemas}')".format(schemas="', '".join(SUPPORTED_SCHEMAS))
+
+
+def connection_string():
+    user = 'username'
+    password = 'password'
+    host = 'localhost'
+    port = '5439'
+    db = 'db'
+    return "postgresql://%s:%s@%s:%s/%s" % (user, password, host, port, db)
+
+
+def create_table_extract_job(**kwargs):
+    where_clause_suffix = textwrap.dedent("""
+        where schemaname in {schemas}
+    """.format(schemas=SUPPORTED_SCHEMA_SQL_IN_CLAUSE))
+
+    tmp_folder = '/var/tmp/amundsen/table_metadata'
+    node_files_folder = '{tmp_folder}/nodes/'.format(tmp_folder=tmp_folder)
+    relationship_files_folder = '{tmp_folder}/relationships/'.format(tmp_folder=tmp_folder)
+
+    job_config = ConfigFactory.from_dict({
+        'extractor.redshift_spectrum_metadata.{}'.format(RedshiftSpectrumMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY):
+            where_clause_suffix,
+        'extractor.redshift_spectrum_metadata.extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            connection_string(),
+        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.NODE_DIR_PATH):
+            node_files_folder,
+        'loader.filesystem_csv_neo4j.{}'.format(FsNeo4jCSVLoader.RELATION_DIR_PATH):
+            relationship_files_folder,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NODE_FILES_DIR):
+            node_files_folder,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR):
+            relationship_files_folder,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY):
+            neo4j_endpoint,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER):
+            neo4j_user,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD):
+            neo4j_password,
+        'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG):
+            'unique_tag',  # should use unique tag here like {ds}
+    })
+    job = DefaultJob(conf=job_config,
+                     task=DefaultTask(extractor=RedshiftSpectrumMetadataExtractor(), loader=FsNeo4jCSVLoader()),
+                     publisher=Neo4jCsvPublisher())
+    return job
+
+
+def create_es_publisher_sample_job():
+    # loader saves data to this location and publisher reads it from here
+    extracted_search_data_path = '/var/tmp/amundsen/search_data.json'
+
+    task = DefaultTask(loader=FSElasticsearchJSONLoader(),
+                       extractor=Neo4jSearchDataExtractor(),
+                       transformer=NoopTransformer())
+
+    # elastic search client instance
+    elasticsearch_client = es
+    # unique name of new index in Elasticsearch
+    elasticsearch_new_index_key = 'tables' + str(uuid.uuid4())
+    # related to mapping type from /databuilder/publisher/elasticsearch_publisher.py#L38
+    elasticsearch_new_index_key_type = 'table'
+    # alias for Elasticsearch used in amundsensearchlibrary/search_service/config.py as an index
+    elasticsearch_index_alias = 'table_search_index'
+
+    job_config = ConfigFactory.from_dict({
+        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): neo4j_endpoint,
+        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY):
+            'databuilder.models.table_elasticsearch_document.TableESDocument',
+        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER): neo4j_user,
+        'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): neo4j_password,
+        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_PATH_CONFIG_KEY):
+            extracted_search_data_path,
+        'loader.filesystem.elasticsearch.{}'.format(FSElasticsearchJSONLoader.FILE_MODE_CONFIG_KEY): 'w',
+        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_PATH_CONFIG_KEY):
+            extracted_search_data_path,
+        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.FILE_MODE_CONFIG_KEY): 'r',
+        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_CLIENT_CONFIG_KEY):
+            elasticsearch_client,
+        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_NEW_INDEX_CONFIG_KEY):
+            elasticsearch_new_index_key,
+        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_DOC_TYPE_CONFIG_KEY):
+            elasticsearch_new_index_key_type,
+        'publisher.elasticsearch.{}'.format(ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY):
+            elasticsearch_index_alias
+    })
+
+    job = DefaultJob(conf=job_config,
+                     task=task,
+                     publisher=ElasticsearchPublisher())
+    return job
+
+
+if __name__ == '__main__':
+    tbljob = create_table_extract_job()
+    tbljob.launch()
+
+    esjob = create_es_publisher_sample_job()
+    esjob.launch()

--- a/tests/unit/extractor/test_redshift_spectrum_metadata_extractor.py
+++ b/tests/unit/extractor/test_redshift_spectrum_metadata_extractor.py
@@ -1,0 +1,249 @@
+import logging
+import unittest
+
+from mock import patch, MagicMock
+from pyhocon import ConfigFactory
+from typing import Any, Dict  # noqa: F401
+
+from databuilder.extractor.redshift_spectrum_metadata_extractor import RedshiftSpectrumMetadataExtractor
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+
+
+class TestRedshiftSpectrumMetadataExtractor(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        logging.basicConfig(level=logging.INFO)
+
+        config_dict = {
+            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+            'TEST_CONNECTION',
+            'extractor.redshift_spectrum_metadata.{}'.format(RedshiftSpectrumMetadataExtractor.CLUSTER_KEY):
+            'MY_CLUSTER',
+            'extractor.redshift_spectrum_metadata.{}'.format(RedshiftSpectrumMetadataExtractor.DATABASE_KEY):
+            'spectrum'
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_extraction_with_empty_query_result(self):
+        # type: () -> None
+        """
+        Test Extraction with empty result from query
+        """
+        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+            extractor = RedshiftSpectrumMetadataExtractor()
+            extractor.init(self.conf)
+
+            results = extractor.extract()
+            self.assertEqual(results, None)
+
+    def test_extraction_with_single_result(self):
+        # type: () -> None
+        with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
+            connection = MagicMock()
+            mock_connection.return_value = connection
+            sql_execute = MagicMock()
+            connection.execute = sql_execute
+            table = {'schema_name': 'test_schema',
+                     'name': 'test_table',
+                     'description': '',
+                     'cluster':
+                     self.conf['extractor.redshift_spectrum_metadata.{}'.format(RedshiftSpectrumMetadataExtractor.CLUSTER_KEY)]
+                     }
+
+            sql_execute.return_value = [
+                self._union(
+                    {'col_name': 'col_id1',
+                     'col_type': 'bigint',
+                     'col_description': '',
+                     'col_sort_order': 0}, table),
+                self._union(
+                    {'col_name': 'col_id2',
+                     'col_type': 'bigint',
+                     'col_description': '',
+                     'col_sort_order': 1}, table),
+                self._union(
+                    {'col_name': 'is_active',
+                     'col_type': 'boolean',
+                     'col_description': '',
+                     'col_sort_order': 2}, table),
+                self._union(
+                    {'col_name': 'source',
+                     'col_type': 'varchar(256)',
+                     'col_description': '',
+                     'col_sort_order': 3}, table),
+                self._union(
+                    {'col_name': 'etl_created_at',
+                     'col_type': 'timestamp',
+                     'col_description': '',
+                     'col_sort_order': 4}, table),
+                self._union(
+                    {'col_name': 'ds',
+                     'col_type': 'varchar(128)',
+                     'col_description': '',
+                     'col_sort_order': 5}, table)
+            ]
+
+            extractor = RedshiftSpectrumMetadataExtractor()
+            extractor.init(self.conf)
+            actual = extractor.extract()
+            expected = TableMetadata('postgres', 'MY_CLUSTER', 'test_schema', 'test_table', '',
+                                     [ColumnMetadata('col_id1', '', 'bigint', 0),
+                                      ColumnMetadata('col_id2', '', 'bigint', 1),
+                                      ColumnMetadata('is_active', '', 'boolean', 2),
+                                      ColumnMetadata('source', '', 'varchar(256)', 3),
+                                      ColumnMetadata('etl_created_at', '', 'timestamp', 4),
+                                      ColumnMetadata('ds', '', 'varchar(128)', 5)])
+
+            self.assertEqual(expected.__repr__(), actual.__repr__())
+            self.assertIsNone(extractor.extract())
+
+    def test_extraction_with_multiple_result(self):
+        # type: () -> None
+        with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
+            connection = MagicMock()
+            mock_connection.return_value = connection
+            sql_execute = MagicMock()
+            connection.execute = sql_execute
+            table = {'schema_name': 'test_schema1',
+                     'name': 'test_table1',
+                     'description': '',
+                     'cluster':
+                     self.conf['extractor.redshift_spectrum_metadata.{}'.format(RedshiftSpectrumMetadataExtractor.CLUSTER_KEY)]
+                     }
+
+            table1 = {'schema_name': 'test_schema1',
+                      'name': 'test_table2',
+                      'description': '',
+                      'cluster':
+                      self.conf['extractor.redshift_spectrum_metadata.{}'.format(RedshiftSpectrumMetadataExtractor.CLUSTER_KEY)]
+                      }
+
+            table2 = {'schema_name': 'test_schema2',
+                      'name': 'test_table3',
+                      'description': '',
+                      'cluster':
+                      self.conf['extractor.redshift_spectrum_metadata.{}'.format(RedshiftSpectrumMetadataExtractor.CLUSTER_KEY)]
+                      }
+
+            sql_execute.return_value = [
+                self._union(
+                    {'col_name': 'col_id1',
+                     'col_type': 'bigint',
+                     'col_description': '',
+                     'col_sort_order': 0}, table),
+                self._union(
+                    {'col_name': 'col_id2',
+                     'col_type': 'bigint',
+                     'col_description': '',
+                     'col_sort_order': 1}, table),
+                self._union(
+                    {'col_name': 'is_active',
+                     'col_type': 'boolean',
+                     'col_description': '',
+                     'col_sort_order': 2}, table),
+                self._union(
+                    {'col_name': 'source',
+                     'col_type': 'varchar',
+                     'col_description': '',
+                     'col_sort_order': 3}, table),
+                self._union(
+                    {'col_name': 'etl_created_at',
+                     'col_type': 'timestamp',
+                     'col_description': '',
+                     'col_sort_order': 4}, table),
+                self._union(
+                    {'col_name': 'ds',
+                     'col_type': 'varchar',
+                     'col_description': '',
+                     'col_sort_order': 5}, table),
+                self._union(
+                    {'col_name': 'col_name',
+                     'col_type': 'varchar',
+                     'col_description': '',
+                     'col_sort_order': 0}, table1),
+                self._union(
+                    {'col_name': 'col_name2',
+                     'col_type': 'varchar',
+                     'col_description': '',
+                     'col_sort_order': 1}, table1),
+                self._union(
+                    {'col_name': 'col_id3',
+                     'col_type': 'varchar',
+                     'col_description': '',
+                     'col_sort_order': 0}, table2),
+                self._union(
+                    {'col_name': 'col_name3',
+                     'col_type': 'varchar',
+                     'col_description': '',
+                     'col_sort_order': 1}, table2)
+            ]
+
+            extractor = RedshiftSpectrumMetadataExtractor()
+            extractor.init(self.conf)
+
+            expected = TableMetadata('postgres',
+                                     self.conf['extractor.redshift_spectrum_metadata.{}'.format(
+                                         RedshiftSpectrumMetadataExtractor.CLUSTER_KEY)],
+                                     'test_schema1', 'test_table1', '',
+                                     [ColumnMetadata('col_id1', '', 'bigint', 0),
+                                      ColumnMetadata('col_id2', '', 'bigint', 1),
+                                      ColumnMetadata('is_active', '', 'boolean', 2),
+                                      ColumnMetadata('source', '', 'varchar', 3),
+                                      ColumnMetadata('etl_created_at', '', 'timestamp', 4),
+                                      ColumnMetadata('ds', '', 'varchar', 5)])
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+
+            expected = TableMetadata('postgres',
+                                     self.conf['extractor.redshift_spectrum_metadata.{}'.format(
+                                         RedshiftSpectrumMetadataExtractor.CLUSTER_KEY)],
+                                     'test_schema1', 'test_table2', '',
+                                     [ColumnMetadata('col_name', '', 'varchar', 0),
+                                      ColumnMetadata('col_name2', '', 'varchar', 1)])
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+
+            expected = TableMetadata('postgres',
+                                     self.conf['extractor.redshift_spectrum_metadata.{}'.format(
+                                         RedshiftSpectrumMetadataExtractor.CLUSTER_KEY)],
+                                     'test_schema2', 'test_table3', '',
+                                     [ColumnMetadata('col_id3', '', 'varchar', 0),
+                                      ColumnMetadata('col_name3', '', 'varchar', 1)])
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+
+            self.assertIsNone(extractor.extract())
+            self.assertIsNone(extractor.extract())
+
+    def _union(self, target, extra):
+        # type: (Dict[Any, Any], Dict[Any, Any]) -> Dict[Any, Any]
+        target.update(extra)
+        return target
+
+
+class TestPostgresMetadataExtractorWithWhereClause(unittest.TestCase):
+    def setUp(self):
+        # type: () -> None
+        logging.basicConfig(level=logging.INFO)
+        self.where_clause_suffix = """
+        where table_schema in ('public_external') and table_name = 'amundsen'
+        """
+
+        config_dict = {
+            RedshiftSpectrumMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
+            'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+                'TEST_CONNECTION'
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_sql_statement(self):
+        # type: () -> None
+        """
+        Test Extraction with empty result from query
+        """
+        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+            extractor = RedshiftSpectrumMetadataExtractor()
+            extractor.init(self.conf)
+            self.assertTrue(self.where_clause_suffix in extractor.sql_stmt)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary of Changes

Resolves https://github.com/lyft/amundsen/issues/65

Added RedshiftSpectrumMetadataExtractor based on the PostgresMetadataExtractor. The main change being a new query that references the `svv_external_columns` table to get spectrum column details instead of the `information_schema.columns` table.

### Tests

Added check single, multiple and where clause tests.

### Documentation

Added sample script to connect to redshift spectrum and publish to Neo4J/ES.
Also added docs to the README file on how to use the extractor.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [] PR passes `make test`
