### PR TITLE
Use config parameter for project_id

### DIFF
--- a/databuilder/extractor/bigquery_watermark_extractor.py
+++ b/databuilder/extractor/bigquery_watermark_extractor.py
@@ -103,7 +103,7 @@ class BigQueryWatermarkExtractor(BaseBigQueryExtractor):
                 table=tableRef['tableId']),
             'useLegacySql': True
         }
-        result = self.bigquery_service.jobs().query(projectId='rea-gcp-dataservices-dev', body=body).execute()
+        result = self.bigquery_service.jobs().query(projectId=self.project_id, body=body).execute()
 
         if 'rows' not in result:
             return


### PR DESCRIPTION
Use configuration parameter for Google Cloud project_id instead of hardcoded.

### Summary of Changes

Use project_id config instead of hard coded value in BigQuery Watermark extractor.

### Tests

Obvious fix. Requires integration to Google Cloud to test.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ x] PR includes a summary of changes. 
- [ x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ x] PR passes `make test`
