### PR TITLE
Fix task stop prematurely if transformer return None

### DIFF
--- a/databuilder/task/task.py
+++ b/databuilder/task/task.py
@@ -60,6 +60,7 @@ class DefaultTask(Task):
             while record:
                 record = self.transformer.transform(record)
                 if not record:
+                    record = self.extractor.extract()
                     continue
                 self.loader.load(record)
                 record = self.extractor.extract()


### PR DESCRIPTION
When transformer returned null no more records is processed, this means a transformer cannot filter out data. It also mean the task silently skip process rest of the records.

### Summary of Changes

When transformer returned null no more records is processed, this means a transformer cannot filter out data. It also mean the task silently skip process rest of the records.

### Tests

No tests exist for this part of the code

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
