### PR TITLE
fix: Use the right scope constant to get bigquery table usage

### DIFF
--- a/databuilder/extractor/base_bigquery_extractor.py
+++ b/databuilder/extractor/base_bigquery_extractor.py
@@ -44,15 +44,15 @@ class BaseBigQueryExtractor(Extractor):
         if self.key_path:
             credentials = (
                 google.oauth2.service_account.Credentials.from_service_account_file(
-                    self.key_path, scopes=BaseBigQueryExtractor._DEFAULT_SCOPES))
+                    self.key_path, scopes=self._DEFAULT_SCOPES))
         else:
             if self.cred_key:
                 service_account_info = json.loads(self.cred_key)
                 credentials = (
                     google.oauth2.service_account.Credentials.from_service_account_info(
-                        service_account_info, scopes=BaseBigQueryExtractor._DEFAULT_SCOPES))
+                        service_account_info, scopes=self._DEFAULT_SCOPES))
             else:
-                credentials, _ = google.auth.default(scopes=BaseBigQueryExtractor._DEFAULT_SCOPES)
+                credentials, _ = google.auth.default(scopes=self._DEFAULT_SCOPES)
 
         http = httplib2.Http()
         authed_http = google_auth_httplib2.AuthorizedHttp(credentials, http=http)


### PR DESCRIPTION
### Summary of Changes

It uses the right class constant to get the const for the scopes, it was working well for the metadata, but not for the usage

### Tests

No test where needed

### Documentation


### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
