### PR TITLE
Fix API throttle handling in BigQueryTableUsageExtractor

### DIFF
--- a/databuilder/extractor/bigquery_usage_extractor.py
+++ b/databuilder/extractor/bigquery_usage_extractor.py
@@ -24,6 +24,7 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
     TIMESTAMP_KEY = 'timestamp'
     _DEFAULT_SCOPES = ('https://www.googleapis.com/auth/cloud-platform',)
     EMAIL_PATTERN = 'email_pattern'
+    DELAY_TIME = 'delay_time'
 
     def init(self, conf):
         # type: (ConfigTree) -> None
@@ -33,6 +34,7 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
             (date.today() - timedelta(days=1)).strftime('%Y-%m-%dT00:00:00Z'))
 
         self.email_pattern = conf.get_string(BigQueryTableUsageExtractor.EMAIL_PATTERN, None)
+        self.delay_time = conf.get_int(BigQueryTableUsageExtractor.DELAY_TIME, 100)
 
         self.table_usage_counts = {}
         self._count_usage()
@@ -136,7 +138,7 @@ class BigQueryTableUsageExtractor(BaseBigQueryExtractor):
                     response = None
             except Exception:
                 # Add a delay when BQ quota exceeds limitation
-                sleep(BigQueryTableUsageExtractor.DELAY_TIME)
+                sleep(self.delay_time)
 
     def get_scope(self):
         # type: () -> str


### PR DESCRIPTION
### Summary of Changes

`DELAY_TIME` was an undefined constant previously. This patch makes
delay timeout configurable using a config param.

Default of 100 seconds as API request quota limits are guaranteed to be
refilled after said time interval accoring to the documentation at:
https://cloud.google.com/compute/docs/api-rate-limits

A better alternative would be an exponential backoff mechanism.

### Tests

No changes.

### Documentation

No documentation changes.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
