### PR TITLE
Made changes to where_clause_suffix to read PostgreSQL column metadata

### DIFF
--- a/example/dags/postgres_sample_dag.py
+++ b/example/dags/postgres_sample_dag.py
@@ -74,8 +74,8 @@ def connection_string():
 
 def create_table_extract_job(**kwargs):
     where_clause_suffix = textwrap.dedent("""
-        where table_schema in {schemas}
-    """)
+        where table_name in {schemas}
+    """).format(schemas=SUPPORTED_SCHEMA_SQL_IN_CLAUSE)
 
     tmp_folder = '/var/tmp/amundsen/table_metadata'
     node_files_folder = '{tmp_folder}/nodes/'.format(tmp_folder=tmp_folder)

--- a/example/dags/postgres_sample_dag.py
+++ b/example/dags/postgres_sample_dag.py
@@ -74,7 +74,7 @@ def connection_string():
 
 def create_table_extract_job(**kwargs):
     where_clause_suffix = textwrap.dedent("""
-        where table_name in {schemas}
+        where table_schema in {schemas}
     """).format(schemas=SUPPORTED_SCHEMA_SQL_IN_CLAUSE)
 
     tmp_folder = '/var/tmp/amundsen/table_metadata'

--- a/example/dags/postgres_sample_dag.py
+++ b/example/dags/postgres_sample_dag.py
@@ -167,4 +167,3 @@ with DAG('amundsen_databuilder', default_args=default_args, **dag_args) as dag:
         task_id='create_es_publisher_sample_job',
         python_callable=create_es_publisher_sample_job
     )
-    

--- a/example/dags/postgres_sample_dag.py
+++ b/example/dags/postgres_sample_dag.py
@@ -167,3 +167,4 @@ with DAG('amundsen_databuilder', default_args=default_args, **dag_args) as dag:
         task_id='create_es_publisher_sample_job',
         python_callable=create_es_publisher_sample_job
     )
+    


### PR DESCRIPTION
### Summary of Changes

The original example script couldn't read my PostgreSQL column metadata. I found that there was a problem with the `where_clause_suffix` variable.

### Tests

No changes

### Documentation
No documentation changes

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
