### PR TITLE
Issue 147/ Programmatic Documentation Notes

### DIFF
--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -8,9 +8,6 @@ from databuilder.models.neo4j_csv_serde import (
     RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE)
 from databuilder.publisher.neo4j_csv_publisher import UNQUOTED_SUFFIX
 
-DESCRIPTION_NODE_LABEL = 'Description'
-
-
 class TagMetadata(Neo4jCsvSerializable):
     TAG_NODE_LABEL = 'Tag'
     TAG_KEY_FORMAT = '{tag}'
@@ -59,6 +56,98 @@ class TagMetadata(Neo4jCsvSerializable):
             return None
 
 
+class DescriptionMetadata:
+    DESCRIPTION_NODE_LABEL = 'Description'
+    PROGRAMMATIC_DESCRIPTION_NODE_LABEL = 'Programmatic_Description'
+    DESCRIPTION_KEY_FORMAT = '{description}'
+    DESCRIPTION_TEXT = 'description'
+    DESCRIPTION_ORDER = 'description_order{}'.format(UNQUOTED_SUFFIX)
+    DESCRIPTION_EDITABLE = 'description_editable{}'.format(UNQUOTED_SUFFIX)
+    DESCRIPTION_SOURCE = 'description_source'
+
+    DESCRIPTION_RELATION_TYPE = 'DESCRIPTION'
+    INVERSE_DESCRIPTION_RELATION_TYPE = 'DESCRIPTION_OF'
+
+    # The default editable source.
+    DEFAULT_SOURCE = "description"
+
+    def __init__(self,
+                 source, # type: str
+                 text,  # type: Union[None, str]
+                 order, # type: int
+                 is_editable=False # type: Union[bool, str]
+                 ):
+        """
+        :param source: The unique source of what is populating this description
+        :param text: the description text. Markdown supported.
+        :param order: the display order. Lower numbers mean it will be displayed first. Ties are handled alphabetically by source.
+        :param is_editable: whether this description is editable.
+        """
+        self._source = source
+        self._text = text
+        if not order:
+            self._order = 0
+        else:
+            self._order = order
+        if isinstance(is_editable, str):
+            self._is_editable = is_editable.lower() == 'true'
+        else:
+            self._is_editable = is_editable
+        # There are so many dependencies on Description node, that it is probably easier to just separate the rest out.
+        if (self._source == self.DEFAULT_SOURCE):
+            self._label = self.DESCRIPTION_NODE_LABEL
+        else:
+            self._label = self.PROGRAMMATIC_DESCRIPTION_NODE_LABEL
+
+    @staticmethod
+    def create_description_metadata(source, text, order, is_editable=False):
+        # We do not want to create a node if there is no description text!
+        if text is None:
+            return None
+        if source is None or source == '':
+            description_node = DescriptionMetadata(DescriptionMetadata.DEFAULT_SOURCE, text, order, True)
+        else:
+            description_node = DescriptionMetadata(source, text, order, is_editable)
+        return description_node
+
+    def get_description_id(self):
+        # type: () -> str
+        if self._source == self.DEFAULT_SOURCE:
+            return "_description"
+        else:
+            return "_description/" + self._source
+
+    def __repr__(self):
+        # type: () -> str
+        return 'DescriptionMetadata({!r}, {!r}, {!r}, {!r})'.format(
+                                                               self._source,
+                                                               self._text,
+                                                               self._order,
+                                                               self._is_editable)
+
+    def get_node_dict(self, node_key):
+        # (str) -> Dict
+        return {
+            NODE_LABEL: self._label,
+            NODE_KEY: node_key,
+            DescriptionMetadata.DESCRIPTION_SOURCE: self._source,
+            DescriptionMetadata.DESCRIPTION_TEXT: self._text,
+            DescriptionMetadata.DESCRIPTION_ORDER: self._order,
+            DescriptionMetadata.DESCRIPTION_EDITABLE: self._is_editable
+        }
+
+    def get_relation(self, start_key, end_key):
+        # (str, str) => Dict
+        return {
+            RELATION_START_LABEL: TableMetadata.TABLE_NODE_LABEL,
+            RELATION_END_LABEL: self._label,
+            RELATION_START_KEY: start_key,
+            RELATION_END_KEY: end_key,
+            RELATION_TYPE: DescriptionMetadata.DESCRIPTION_RELATION_TYPE,
+            RELATION_REVERSE_TYPE: DescriptionMetadata.INVERSE_DESCRIPTION_RELATION_TYPE
+        }
+
+
 class ColumnMetadata:
     COLUMN_NODE_LABEL = 'Column'
     COLUMN_KEY_FORMAT = '{db}://{cluster}.{schema}/{tbl}/{col}'
@@ -66,11 +155,7 @@ class ColumnMetadata:
     COLUMN_TYPE = 'type'
     COLUMN_ORDER = 'sort_order{}'.format(UNQUOTED_SUFFIX)  # int value needs to be unquoted when publish to neo4j
     COLUMN_DESCRIPTION = 'description'
-    COLUMN_DESCRIPTION_FORMAT = '{db}://{cluster}.{schema}/{tbl}/{col}/_description'
-
-    # pair of nodes makes relationship where name of variable represents order of relationship.
-    COL_DESCRIPTION_RELATION_TYPE = 'DESCRIPTION'
-    DESCRIPTION_COL_RELATION_TYPE = 'DESCRIPTION_OF'
+    COLUMN_DESCRIPTION_FORMAT = '{db}://{cluster}.{schema}/{tbl}/{col}/{description_id}'
 
     # Relation between column and tag
     COL_TAG_RELATION_TYPE = 'TAGGED_BY'
@@ -81,7 +166,10 @@ class ColumnMetadata:
                  description,  # type: Union[str, None]
                  col_type,  # type: str
                  sort_order,  # type: int
-                 tags=None,  # Union[List[str], None]
+                 tags=None,  # type: Union[List[str], None]
+                 description_source=None, # type: Union[str, None]
+                 description_editable=False, # type: bool
+                 description_order=0
                  ):
         # type: (...) -> None
         """
@@ -92,7 +180,9 @@ class ColumnMetadata:
         :param sort_order:
         """
         self.name = name
-        self.description = description
+        #TODO figureo out order
+        self.description = DescriptionMetadata.create_description_metadata(description_source,
+                                                                           description, description_order, description_editable)
         self.type = col_type
         self.sort_order = sort_order
         self.tags = tags
@@ -126,10 +216,7 @@ class TableMetadata(Neo4jCsvSerializable):
     TABLE_NAME = 'name'
     IS_VIEW = 'is_view{}'.format(UNQUOTED_SUFFIX)  # bool value needs to be unquoted when publish to neo4j
 
-    TABLE_DESCRIPTION = 'description'
-    TABLE_DESCRIPTION_FORMAT = '{db}://{cluster}.{schema}/{tbl}/_description'
-    TABLE_DESCRIPTION_RELATION_TYPE = 'DESCRIPTION'
-    DESCRIPTION_TABLE_RELATION_TYPE = 'DESCRIPTION_OF'
+    TABLE_DESCRIPTION_FORMAT = '{db}://{cluster}.{schema}/{tbl}/{description_id}'
 
     DATABASE_NODE_LABEL = 'Database'
     DATABASE_KEY_FORMAT = 'database://{db}'
@@ -165,6 +252,9 @@ class TableMetadata(Neo4jCsvSerializable):
                  columns=None,  # type: Iterable[ColumnMetadata]
                  is_view=False,  # type: bool
                  tags=None,  # type: Union[List, str]
+                 description_source=None, # type: Union[str, None]
+                 description_editable=False, # type: bool
+                 description_order=0,
                  **kwargs  # type: Dict
                  ):
         # type: (...) -> None
@@ -177,13 +267,16 @@ class TableMetadata(Neo4jCsvSerializable):
         :param columns:
         :param is_view: Indicate whether the table is a view or not
         :param tags:
+        :param description_source: Optional. Where the description is coming from.
         :param kwargs: Put additional attributes to the table model if there is any.
         """
         self.database = database
         self.cluster = cluster
         self.schema_name = schema_name
         self.name = name
-        self.description = description
+        #TODO figure out order
+        self.description = DescriptionMetadata.create_description_metadata(description_source,
+                                                                           description, description_order, description_editable)
         self.columns = columns if columns else []
         self.is_view = is_view
         self.attrs = None
@@ -218,12 +311,13 @@ class TableMetadata(Neo4jCsvSerializable):
                                                      schema=self.schema_name,
                                                      tbl=self.name)
 
-    def _get_table_description_key(self):
-        # type: () -> str
+    def _get_table_description_key(self, description):
+        # type: (DescriptionMetadata) -> str
         return TableMetadata.TABLE_DESCRIPTION_FORMAT.format(db=self.database,
                                                              cluster=self.cluster,
                                                              schema=self.schema_name,
-                                                             tbl=self.name)
+                                                             tbl=self.name,
+                                                             description_id=description.get_description_id())
 
     def _get_database_key(self):
         # type: () -> str
@@ -248,13 +342,14 @@ class TableMetadata(Neo4jCsvSerializable):
                                                        tbl=self.name,
                                                        col=col.name)
 
-    def _get_col_description_key(self, col):
-        # type: (ColumnMetadata) -> str
+    def _get_col_description_key(self, col, description):
+        # type: (ColumnMetadata, DescriptionMetadata) -> str
         return ColumnMetadata.COLUMN_DESCRIPTION_FORMAT.format(db=self.database,
                                                                cluster=self.cluster,
                                                                schema=self.schema_name,
                                                                tbl=self.name,
-                                                               col=col.name)
+                                                               col=col.name,
+                                                               description_id=description.get_description_id())
 
     def create_next_node(self):
         # type: () -> Union[Dict[str, Any], None]
@@ -277,9 +372,8 @@ class TableMetadata(Neo4jCsvSerializable):
         yield table_node
 
         if self.description:
-            yield {NODE_LABEL: DESCRIPTION_NODE_LABEL,
-                   NODE_KEY: self._get_table_description_key(),
-                   TableMetadata.TABLE_DESCRIPTION: self.description}
+            node_key = self._get_table_description_key(self.description)
+            yield self.description.get_node_dict(node_key)
 
         # Create the table tag node
         if self.tags:
@@ -294,21 +388,15 @@ class TableMetadata(Neo4jCsvSerializable):
                 ColumnMetadata.COLUMN_TYPE: col.type,
                 ColumnMetadata.COLUMN_ORDER: col.sort_order}
 
-            if not col.description:
-                continue
+            if col.description:
+                node_key = self._get_col_description_key(col, col.description)
+                yield col.description.get_node_dict(node_key)
 
-            yield {
-                NODE_LABEL: DESCRIPTION_NODE_LABEL,
-                NODE_KEY: self._get_col_description_key(col),
-                ColumnMetadata.COLUMN_DESCRIPTION: col.description}
-
-            if not col.tags:
-                continue
-
-            for tag in col.tags:
-                yield {NODE_LABEL: TagMetadata.TAG_NODE_LABEL,
-                       NODE_KEY: TagMetadata.get_tag_key(tag),
-                       TagMetadata.TAG_TYPE: 'default'}
+            if col.tags:
+                for tag in col.tags:
+                    yield {NODE_LABEL: TagMetadata.TAG_NODE_LABEL,
+                           NODE_KEY: TagMetadata.get_tag_key(tag),
+                           TagMetadata.TAG_TYPE: 'default'}
 
         # Database, cluster, schema
         others = [NodeTuple(key=self._get_database_key(),
@@ -351,14 +439,7 @@ class TableMetadata(Neo4jCsvSerializable):
         }
 
         if self.description:
-            yield {
-                RELATION_START_LABEL: TableMetadata.TABLE_NODE_LABEL,
-                RELATION_END_LABEL: DESCRIPTION_NODE_LABEL,
-                RELATION_START_KEY: self._get_table_key(),
-                RELATION_END_KEY: self._get_table_description_key(),
-                RELATION_TYPE: TableMetadata.TABLE_DESCRIPTION_RELATION_TYPE,
-                RELATION_REVERSE_TYPE: TableMetadata.DESCRIPTION_TABLE_RELATION_TYPE
-            }
+            yield self.description.get_relation(self._get_table_key(), self._get_table_description_key(self.description))
 
         if self.tags:
             for tag in self.tags:
@@ -381,30 +462,19 @@ class TableMetadata(Neo4jCsvSerializable):
                 RELATION_REVERSE_TYPE: TableMetadata.COL_TABLE_RELATION_TYPE
             }
 
-            if not col.description:
-                continue
+            if col.description:
+                yield col.description.get_relation(self._get_col_key(col), self._get_col_description_key(col, col.description))
 
-            yield {
-                RELATION_START_LABEL: ColumnMetadata.COLUMN_NODE_LABEL,
-                RELATION_END_LABEL: DESCRIPTION_NODE_LABEL,
-                RELATION_START_KEY: self._get_col_key(col),
-                RELATION_END_KEY: self._get_col_description_key(col),
-                RELATION_TYPE: ColumnMetadata.COL_DESCRIPTION_RELATION_TYPE,
-                RELATION_REVERSE_TYPE: ColumnMetadata.DESCRIPTION_COL_RELATION_TYPE
-            }
-
-            if not col.tags:
-                continue
-
-            for tag in col.tags:
-                yield {
-                    RELATION_START_LABEL: TableMetadata.TABLE_NODE_LABEL,
-                    RELATION_END_LABEL: TagMetadata.TAG_NODE_LABEL,
-                    RELATION_START_KEY: self._get_table_key(),
-                    RELATION_END_KEY: TagMetadata.get_tag_key(tag),
-                    RELATION_TYPE: ColumnMetadata.COL_TAG_RELATION_TYPE,
-                    RELATION_REVERSE_TYPE: ColumnMetadata.TAG_COL_RELATION_TYPE,
-                }
+            if col.tags:
+                for tag in col.tags:
+                    yield {
+                        RELATION_START_LABEL: TableMetadata.TABLE_NODE_LABEL,
+                        RELATION_END_LABEL: TagMetadata.TAG_NODE_LABEL,
+                        RELATION_START_KEY: self._get_table_key(),
+                        RELATION_END_KEY: TagMetadata.get_tag_key(tag),
+                        RELATION_TYPE: ColumnMetadata.COL_TAG_RELATION_TYPE,
+                        RELATION_REVERSE_TYPE: ColumnMetadata.TAG_COL_RELATION_TYPE,
+                    }
 
         others = [
             RelTuple(start_label=TableMetadata.DATABASE_NODE_LABEL,

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -243,6 +243,7 @@ class TableMetadata(Neo4jCsvSerializable):
     serialized_nodes = set()  # type: Set[Any]
     serialized_rels = set()  # type: Set[Any]
 
+    #TODO I would prefer to have description be either of type string or of type DescriptionMetadata to eliminate constructor bloat
     def __init__(self,
                  database,  # type: str
                  cluster,  # type: str

--- a/example/sample_data/sample_col.csv
+++ b/example/sample_data/sample_col.csv
@@ -9,3 +9,4 @@ col2,"col2 description","string",2,dynamo,gold,test_schema,test_table2
 col3,"col3 description","string",3,dynamo,gold,test_schema,test_table2
 col4,"col4 description","int",4,dynamo,gold,test_schema,test_table2
 col1,"view col description","int",1,hive,gold,test_schema,test_view1
+col1,"col1 description","int",1,hive,gold,test_schema,test_table3,""

--- a/example/sample_data/sample_table.csv
+++ b/example/sample_data/sample_table.csv
@@ -2,3 +2,4 @@ database,cluster,schema_name,name,description,tags,is_view,description_source
 hive,gold,test_schema,test_table1,"1st test table","tag1,tag2,pii,high_quality",false,
 dynamo,gold,test_schema,test_table2,"2nd test table","high_quality,recommended",false,
 hive,gold,test_schema,test_view1,"1st test view","tag1",true,
+hive,gold,test_schema,test_table3,"3rd test","needs_documentation",false,

--- a/example/sample_data/sample_table.csv
+++ b/example/sample_data/sample_table.csv
@@ -1,4 +1,4 @@
-database,cluster,schema_name,name,description,tags,is_view
-hive,gold,test_schema,test_table1,"1st test table","tag1,tag2,pii,high_quality",false
-dynamo,gold,test_schema,test_table2,"2nd test table","high_quality,recommended",false
-hive,gold,test_schema,test_view1,"1st test view","tag1",true
+database,cluster,schema_name,name,description,tags,is_view,description_source
+hive,gold,test_schema,test_table1,"1st test table","tag1,tag2,pii,high_quality",false,
+dynamo,gold,test_schema,test_table2,"2nd test table","high_quality,recommended",false,
+hive,gold,test_schema,test_view1,"1st test view","tag1",true,

--- a/example/sample_data/sample_table_programmatic_source.csv
+++ b/example/sample_data/sample_table_programmatic_source.csv
@@ -1,4 +1,4 @@
-database,cluster,schema_name,name,description,tags,description_source,description_editable
-hive,gold,test_schema,test_table1,"**Size**: 50T\n\n**Monthly Cost**: $5000","expensive","s3_crawler",false
-dynamo,gold,test_schema,test_table2,"**Size**: 1T\n\n**Monthly Cost**: $500",,"s3_crawler",false
-hive,gold,test_schema,test_table1,"### Quality Report:\n --- \n Ipsus enom. Ipsus enom ipsus lorenum.\n ---\n[![Build Status](https://api.travis-ci.com/lyft/amundsendatabuilder.svg?branch=master)](https://travis-ci.com/lyft/amundsendatabuilder)","low_quality","quality_service",false
+database,cluster,schema_name,name,description,tags,description_source
+hive,gold,test_schema,test_table1,"**Size**: 50T\n\n**Monthly Cost**: $5000","expensive","s3_crawler"
+dynamo,gold,test_schema,test_table2,"**Size**: 1T\n\n**Monthly Cost**: $50","cheap","s3_crawler"
+hive,gold,test_schema,test_table1,"### Quality Report:\n --- \n Ipsus enom. Ipsus enom ipsus lorenum.\n ---\n[![Build Status](https://api.travis-ci.com/lyft/amundsendatabuilder.svg?branch=master)](https://travis-ci.com/lyft/amundsendatabuilder)","low_quality","quality_service"

--- a/example/sample_data/sample_table_programmatic_source.csv
+++ b/example/sample_data/sample_table_programmatic_source.csv
@@ -1,4 +1,4 @@
-database,cluster,schema_name,name,description,tags,description_source,description_editable,description_order
-hive,gold,test_schema,test_table1,"**Size**: 50T\n\n**Monthly Cost**: $5000","expensive","s3_crawler",false,1
-dynamo,gold,test_schema,test_table2,"**Size**: 1T\n\n**Monthly Cost**: $500",,"s3_crawler",false,1
-hive,gold,test_schema,test_table1,"### Quality Report:\n --- \n Ipsus enom. Ipsus enom ipsus lorenum.\n ---\n[![Build Status](https://api.travis-ci.com/lyft/amundsendatabuilder.svg?branch=master)](https://travis-ci.com/lyft/amundsendatabuilder)","low_quality","quality_service",false,1
+database,cluster,schema_name,name,description,tags,description_source,description_editable
+hive,gold,test_schema,test_table1,"**Size**: 50T\n\n**Monthly Cost**: $5000","expensive","s3_crawler",false
+dynamo,gold,test_schema,test_table2,"**Size**: 1T\n\n**Monthly Cost**: $500",,"s3_crawler",false
+hive,gold,test_schema,test_table1,"### Quality Report:\n --- \n Ipsus enom. Ipsus enom ipsus lorenum.\n ---\n[![Build Status](https://api.travis-ci.com/lyft/amundsendatabuilder.svg?branch=master)](https://travis-ci.com/lyft/amundsendatabuilder)","low_quality","quality_service",false

--- a/example/sample_data/sample_table_programmatic_source.csv
+++ b/example/sample_data/sample_table_programmatic_source.csv
@@ -1,0 +1,4 @@
+database,cluster,schema_name,name,description,tags,description_source,description_editable,description_order
+hive,gold,test_schema,test_table1,"**Size**: 50T\n\n**Monthly Cost**: $5000","expensive","s3_crawler",false,1
+dynamo,gold,test_schema,test_table2,"**Size**: 1T\n\n**Monthly Cost**: $500",,"s3_crawler",false,1
+hive,gold,test_schema,test_table1,"### Quality Report:\n --- \n Ipsus enom. Ipsus enom ipsus lorenum.\n ---\n[![Build Status](https://api.travis-ci.com/lyft/amundsendatabuilder.svg?branch=master)](https://travis-ci.com/lyft/amundsendatabuilder)","low_quality","quality_service",false,1

--- a/example/scripts/sample_data_loader.py
+++ b/example/scripts/sample_data_loader.py
@@ -76,8 +76,7 @@ def load_table_data_from_csv(file_name, table_name):
                     'description VARCHAR(64) NOT NULL, '
                     'tags VARCHAR(128) NOT NULL,'
                     'description_source VARCHAR(32),'
-                    'description_editable boolean,'
-                    'description_order INT)'.format(table_name))
+                    'description_editable boolean)'.format(table_name))
         file_loc = 'example/sample_data/' + file_name
         with open(file_loc, 'r') as fin:
             dr = csv.DictReader(fin)
@@ -88,12 +87,12 @@ def load_table_data_from_csv(file_name, table_name):
                       i['description'],
                       i['tags'],
                       i['description_source'],
-                      i['description_editable'],
-                      i['description_order']) for i in dr]
+                      i['description_editable']) for i in dr]
 
         cur.executemany("INSERT INTO {} (database, cluster, "
                         "schema_name, name, description, tags, "
-                        "description_source, description_editable, description_order) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);".format(table_name), to_db)
+                        "description_source, description_editable) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?);".format(table_name), to_db)
         conn.commit()
 
 

--- a/example/scripts/sample_data_loader.py
+++ b/example/scripts/sample_data_loader.py
@@ -75,8 +75,7 @@ def load_table_data_from_csv(file_name, table_name):
                     'name VARCHAR(64) NOT NULL,'
                     'description VARCHAR(64) NOT NULL, '
                     'tags VARCHAR(128) NOT NULL,'
-                    'description_source VARCHAR(32),'
-                    'description_editable boolean)'.format(table_name))
+                    'description_source VARCHAR(32))'.format(table_name))
         file_loc = 'example/sample_data/' + file_name
         with open(file_loc, 'r') as fin:
             dr = csv.DictReader(fin)
@@ -86,13 +85,12 @@ def load_table_data_from_csv(file_name, table_name):
                       i['name'],
                       i['description'],
                       i['tags'],
-                      i['description_source'],
-                      i['description_editable']) for i in dr]
+                      i['description_source']) for i in dr]
 
         cur.executemany("INSERT INTO {} (database, cluster, "
                         "schema_name, name, description, tags, "
-                        "description_source, description_editable) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?);".format(table_name), to_db)
+                        "description_source) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?);".format(table_name), to_db)
         conn.commit()
 
 

--- a/example/scripts/sample_data_loader.py
+++ b/example/scripts/sample_data_loader.py
@@ -112,42 +112,6 @@ def load_tag_data_from_csv(file_name):
         conn.commit()
 
 
-def load_col_data_from_csv(file_name):
-    conn = create_connection(DB_FILE)
-    if conn:
-        cur = conn.cursor()
-        cur.execute('drop table if exists test_col_metadata')
-        cur.execute('create table if not exists test_col_metadata '
-                    '(name VARCHAR(64) NOT NULL , '
-                    'description VARCHAR(64) NOT NULL , '
-                    'col_type VARCHAR(64) NOT NULL , '
-                    'sort_order INTEGER NOT NULL , '
-                    'database VARCHAR(64) NOT NULL , '
-                    'cluster VARCHAR(64) NOT NULL, '
-                    'schema_name VARCHAR(64) NOT NULL,'
-                    'table_name VARCHAR(64) NOT NULL,'
-                    'table_description VARCHAR(64) NOT NULL)')
-        file_loc = 'example/sample_data/' + file_name
-        with open(file_loc, 'r') as fin:
-            dr = csv.DictReader(fin)
-            to_db = [(i['name'],
-                      i['description'],
-                      i['col_type'],
-                      i['sort_order'],
-                      i['database'],
-                      i['cluster'],
-                      i['schema_name'],
-                      i['table_name'],
-                      i['table_description']) for i in dr]
-
-        cur.executemany("INSERT INTO test_col_metadata ("
-                        "name, description, col_type, sort_order,"
-                        "database, cluster, "
-                        "schema_name, table_name, table_description) VALUES "
-                        "(?, ?, ?, ?, ?, ?, ?, ?, ?);", to_db)
-        conn.commit()
-
-
 def load_table_column_stats_from_csv(file_name):
     conn = create_connection(DB_FILE)
     if conn:
@@ -676,7 +640,6 @@ if __name__ == "__main__":
     # logging.basicConfig(level=logging.INFO)
 
     load_table_data_from_csv('sample_table_programmatic_source.csv', 'programmatic')
-    load_col_data_from_csv('sample_col.csv')
     load_table_column_stats_from_csv('sample_table_column_stats.csv')
     load_watermark_data_from_csv('sample_watermark.csv')
     load_table_owner_data_from_csv('sample_table_owner.csv')

--- a/example/scripts/sample_data_loader.py
+++ b/example/scripts/sample_data_loader.py
@@ -63,18 +63,21 @@ def create_connection(db_file):
     return None
 
 
-def load_table_data_from_csv(file_name):
+def load_table_data_from_csv(file_name, table_name):
     conn = create_connection(DB_FILE)
     if conn:
         cur = conn.cursor()
-        cur.execute('drop table if exists test_table_metadata')
-        cur.execute('create table if not exists test_table_metadata '
+        cur.execute('drop table if exists {}'.format(table_name))
+        cur.execute('create table if not exists {} '
                     '(database VARCHAR(64) NOT NULL , '
                     'cluster VARCHAR(64) NOT NULL, '
                     'schema_name VARCHAR(64) NOT NULL,'
                     'name VARCHAR(64) NOT NULL,'
                     'description VARCHAR(64) NOT NULL, '
-                    'tags VARCHAR(128) NOT NULL)')
+                    'tags VARCHAR(128) NOT NULL,'
+                    'description_source VARCHAR(32),'
+                    'description_editable boolean,'
+                    'description_order INT)'.format(table_name))
         file_loc = 'example/sample_data/' + file_name
         with open(file_loc, 'r') as fin:
             dr = csv.DictReader(fin)
@@ -83,10 +86,14 @@ def load_table_data_from_csv(file_name):
                       i['schema_name'],
                       i['name'],
                       i['description'],
-                      i['tags']) for i in dr]
+                      i['tags'],
+                      i['description_source'],
+                      i['description_editable'],
+                      i['description_order']) for i in dr]
 
-        cur.executemany("INSERT INTO test_table_metadata (database, cluster, "
-                        "schema_name, name, description, tags) VALUES (?, ?, ?, ?, ?, ?);", to_db)
+        cur.executemany("INSERT INTO {} (database, cluster, "
+                        "schema_name, name, description, tags, "
+                        "description_source, description_editable, description_order) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);".format(table_name), to_db)
         conn.commit()
 
 
@@ -671,6 +678,8 @@ if __name__ == "__main__":
     # Uncomment next line to get INFO level logging
     # logging.basicConfig(level=logging.INFO)
 
+    load_table_data_from_csv('sample_table_programmatic_source.csv', 'programmatic')
+    load_col_data_from_csv('sample_col.csv')
     load_table_column_stats_from_csv('sample_table_column_stats.csv')
     load_watermark_data_from_csv('sample_watermark.csv')
     load_table_owner_data_from_csv('sample_table_owner.csv')
@@ -692,6 +701,11 @@ if __name__ == "__main__":
             col_path
         )
         table_and_col_job.launch()
+
+        # start programmatic table job
+        job2 = create_sample_job('programmatic',
+                                 'databuilder.models.table_metadata.TableMetadata')
+        job2.launch()
 
         # start table stats job
         job_table_stats = create_sample_job('test_table_column_stats',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '1.5.2'
+__version__ = '1.6.1'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -189,7 +189,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEquals(result.cluster, 'your-project-here')
         self.assertEquals(result.schema_name, 'fdgdfgh')
         self.assertEquals(result.name, 'nested_recs')
-        self.assertEquals(result.description, '')
+        self.assertEquals(result.description._text, '')
         self.assertEquals(result.columns, [])
         self.assertEquals(result.is_view, False)
 

--- a/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -205,7 +205,7 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEquals(result.cluster, 'your-project-here')
         self.assertEquals(result.schema_name, 'fdgdfgh')
         self.assertEquals(result.name, 'nested_recs')
-        self.assertEquals(result.description, '')
+        self.assertEquals(result.description._text, "")
         self.assertEquals(result.columns, [])
         self.assertEquals(result.is_view, False)
 
@@ -231,12 +231,12 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
         self.assertEquals(result.cluster, 'your-project-here')
         self.assertEquals(result.schema_name, 'fdgdfgh')
         self.assertEquals(result.name, 'nested_recs')
-        self.assertEquals(result.description, '')
+        self.assertEquals(result.description._text, "")
 
         first_col = result.columns[0]
         self.assertEquals(first_col.name, 'test')
         self.assertEquals(first_col.type, 'STRING')
-        self.assertEquals(first_col.description, 'some_description')
+        self.assertEquals(first_col.description._text, 'some_description')
         self.assertEquals(result.is_view, False)
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')

--- a/tests/unit/extractor/test_csv_extractor.py
+++ b/tests/unit/extractor/test_csv_extractor.py
@@ -27,7 +27,7 @@ class TestCsvExtractor(unittest.TestCase):
 
         result = extractor.extract()
         self.assertEquals(result.name, 'test_table1')
-        self.assertEquals(result.description, '1st test table')
+        self.assertEquals(result.description._text, '1st test table')
         self.assertEquals(result.database, 'hive')
         self.assertEquals(result.cluster, 'gold')
         self.assertEquals(result.schema_name, 'test_schema')

--- a/tests/unit/models/test_table_metadata.py
+++ b/tests/unit/models/test_table_metadata.py
@@ -31,28 +31,28 @@ class TestTableMetadata(unittest.TestCase):
             {'name': 'test_table1', 'KEY': 'hive://gold.test_schema1/test_table1', 'LABEL': 'Table',
              'is_view:UNQUOTED': False},
             {'description': 'test_table1', 'KEY': 'hive://gold.test_schema1/test_table1/_description',
-             'LABEL': 'Description', 'description_order:UNQUOTED': 0, 'description_editable:UNQUOTED': True, 'description_source': 'description'},
+             'LABEL': 'Description', 'description_editable:UNQUOTED': True, 'description_source': 'description'},
             {'sort_order:UNQUOTED': 0, 'type': 'bigint', 'name': 'test_id1',
              'KEY': 'hive://gold.test_schema1/test_table1/test_id1', 'LABEL': 'Column'},
             {'description': 'description of test_table1',
              'KEY': 'hive://gold.test_schema1/test_table1/test_id1/_description', 'LABEL': 'Description',
-             'description_order:UNQUOTED': 0, 'description_editable:UNQUOTED': True, 'description_source': 'description'},
+             'description_editable:UNQUOTED': True, 'description_source': 'description'},
             {'sort_order:UNQUOTED': 1, 'type': 'bigint', 'name': 'test_id2',
              'KEY': 'hive://gold.test_schema1/test_table1/test_id2', 'LABEL': 'Column'},
             {'description': 'description of test_id2',
-             'KEY': 'hive://gold.test_schema1/test_table1/test_id2/_description', 'LABEL': 'Description',
-             'description_order:UNQUOTED': 0, 'description_editable:UNQUOTED': True,'description_source': 'description'},
+             'KEY': 'hive://gold.test_schema1/test_table1/test_id2/_description',
+             'LABEL': 'Description', 'description_editable:UNQUOTED': True, 'description_source': 'description'},
             {'sort_order:UNQUOTED': 2, 'type': 'boolean', 'name': 'is_active',
              'KEY': 'hive://gold.test_schema1/test_table1/is_active', 'LABEL': 'Column'},
             {'sort_order:UNQUOTED': 3, 'type': 'varchar', 'name': 'source',
              'KEY': 'hive://gold.test_schema1/test_table1/source', 'LABEL': 'Column'},
             {'description': 'description of source', 'KEY': 'hive://gold.test_schema1/test_table1/source/_description',
-             'LABEL': 'Description', 'description_order:UNQUOTED': 0, 'description_editable:UNQUOTED': True,'description_source': 'description'},
+             'LABEL': 'Description', 'description_editable:UNQUOTED': True, 'description_source': 'description'},
             {'sort_order:UNQUOTED': 4, 'type': 'timestamp', 'name': 'etl_created_at',
              'KEY': 'hive://gold.test_schema1/test_table1/etl_created_at', 'LABEL': 'Column'},
             {'description': 'description of etl_created_at',
              'KEY': 'hive://gold.test_schema1/test_table1/etl_created_at/_description', 'LABEL': 'Description',
-             'description_order:UNQUOTED': 0, 'description_editable:UNQUOTED': True, 'description_source': 'description'},
+             'description_editable:UNQUOTED': True, 'description_source': 'description'},
             {'sort_order:UNQUOTED': 5, 'type': 'varchar', 'name': 'ds',
              'KEY': 'hive://gold.test_schema1/test_table1/ds', 'LABEL': 'Column'}
         ]
@@ -117,8 +117,10 @@ class TestTableMetadata(unittest.TestCase):
         while relation_row:
             actual.append(relation_row)
             relation_row = self.table_metadata.next_relation()
-
-        self.assertEqual(self.expected_rels, actual)
+        for i in range(0, len(self.expected_rels)):
+            print(self.expected_rels[i])
+            print(actual[i])
+            self.assertEqual(actual[i], self.expected_rels[i])
 
         # 2nd record should not show already serialized database, cluster, and schema
         node_row = self.table_metadata2.next_node()
@@ -156,32 +158,28 @@ class TestTableMetadata(unittest.TestCase):
         self.assertEqual(actual[0].get('attr1'), 'uri')
         self.assertEqual(actual[0].get('attr2'), 'attr2')
 
-    #TODO NO test can run before serialiable... need to fix
+    # TODO NO test can run before serialiable... need to fix
     def test_z_custom_sources(self):
         # type: () -> None
         self.custom_source = TableMetadata('hive', 'gold', 'test_schema3', 'test_table4', 'test_table4', [
-            ColumnMetadata('test_id1', 'description of test_table1', 'bigint', 0, description_source="custom"),
+            ColumnMetadata('test_id1', 'description of test_table1', 'bigint', 0),
             ColumnMetadata('test_id2', 'description of test_id2', 'bigint', 1),
             ColumnMetadata('is_active', None, 'boolean', 2),
             ColumnMetadata('source', 'description of source', 'varchar', 3),
             ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
             ColumnMetadata('ds', None, 'varchar', 5)], is_view=False,
-                                             description_editable=False, description_source="custom",
-                                             description_order=2)
+            description_editable=False, description_source="custom")
 
         node_row = self.custom_source.next_node()
         actual = []
         while node_row:
             actual.append(node_row)
             node_row = self.custom_source.next_node()
-        expected = {'LABEL': 'Programmatic_Description', 'KEY': 'hive://gold.test_schema3/test_table4/_description/custom',
-                    'description_source': 'custom', 'description': 'test_table4', 'description_order:UNQUOTED': 2,
+        expected = {'LABEL': 'Programmatic_Description',
+                    'KEY': 'hive://gold.test_schema3/test_table4/_description/custom',
+                    'description_source': 'custom', 'description': 'test_table4',
                     'description_editable:UNQUOTED': False}
         self.assertEqual(actual[1], expected)
-        expected2 = {'LABEL': 'Programmatic_Description', 'KEY': 'hive://gold.test_schema3/test_table4/test_id1/_description/custom',
-                    'description_source': 'custom', 'description': 'description of test_table1', 'description_order:UNQUOTED': 0,
-                    'description_editable:UNQUOTED': False}
-        self.assertEqual(actual[3], expected2)
 
     def test_tags_field(self):
         # type: () -> None

--- a/tests/unit/models/test_table_metadata.py
+++ b/tests/unit/models/test_table_metadata.py
@@ -31,25 +31,28 @@ class TestTableMetadata(unittest.TestCase):
             {'name': 'test_table1', 'KEY': 'hive://gold.test_schema1/test_table1', 'LABEL': 'Table',
              'is_view:UNQUOTED': False},
             {'description': 'test_table1', 'KEY': 'hive://gold.test_schema1/test_table1/_description',
-             'LABEL': 'Description'},
+             'LABEL': 'Description', 'description_order:UNQUOTED': 0, 'description_editable:UNQUOTED': True, 'description_source': 'description'},
             {'sort_order:UNQUOTED': 0, 'type': 'bigint', 'name': 'test_id1',
              'KEY': 'hive://gold.test_schema1/test_table1/test_id1', 'LABEL': 'Column'},
             {'description': 'description of test_table1',
-             'KEY': 'hive://gold.test_schema1/test_table1/test_id1/_description', 'LABEL': 'Description'},
+             'KEY': 'hive://gold.test_schema1/test_table1/test_id1/_description', 'LABEL': 'Description',
+             'description_order:UNQUOTED': 0, 'description_editable:UNQUOTED': True, 'description_source': 'description'},
             {'sort_order:UNQUOTED': 1, 'type': 'bigint', 'name': 'test_id2',
              'KEY': 'hive://gold.test_schema1/test_table1/test_id2', 'LABEL': 'Column'},
             {'description': 'description of test_id2',
-             'KEY': 'hive://gold.test_schema1/test_table1/test_id2/_description', 'LABEL': 'Description'},
+             'KEY': 'hive://gold.test_schema1/test_table1/test_id2/_description', 'LABEL': 'Description',
+             'description_order:UNQUOTED': 0, 'description_editable:UNQUOTED': True,'description_source': 'description'},
             {'sort_order:UNQUOTED': 2, 'type': 'boolean', 'name': 'is_active',
              'KEY': 'hive://gold.test_schema1/test_table1/is_active', 'LABEL': 'Column'},
             {'sort_order:UNQUOTED': 3, 'type': 'varchar', 'name': 'source',
              'KEY': 'hive://gold.test_schema1/test_table1/source', 'LABEL': 'Column'},
             {'description': 'description of source', 'KEY': 'hive://gold.test_schema1/test_table1/source/_description',
-             'LABEL': 'Description'},
+             'LABEL': 'Description', 'description_order:UNQUOTED': 0, 'description_editable:UNQUOTED': True,'description_source': 'description'},
             {'sort_order:UNQUOTED': 4, 'type': 'timestamp', 'name': 'etl_created_at',
              'KEY': 'hive://gold.test_schema1/test_table1/etl_created_at', 'LABEL': 'Column'},
             {'description': 'description of etl_created_at',
-             'KEY': 'hive://gold.test_schema1/test_table1/etl_created_at/_description', 'LABEL': 'Description'},
+             'KEY': 'hive://gold.test_schema1/test_table1/etl_created_at/_description', 'LABEL': 'Description',
+             'description_order:UNQUOTED': 0, 'description_editable:UNQUOTED': True, 'description_source': 'description'},
             {'sort_order:UNQUOTED': 5, 'type': 'varchar', 'name': 'ds',
              'KEY': 'hive://gold.test_schema1/test_table1/ds', 'LABEL': 'Column'}
         ]
@@ -106,8 +109,8 @@ class TestTableMetadata(unittest.TestCase):
         while node_row:
             actual.append(node_row)
             node_row = self.table_metadata.next_node()
-
-        self.assertEqual(self.expected_nodes, actual)
+        for i in range(0, len(self.expected_nodes)):
+            self.assertEqual(actual[i], self.expected_nodes[i])
 
         relation_row = self.table_metadata.next_relation()
         actual = []
@@ -152,6 +155,33 @@ class TestTableMetadata(unittest.TestCase):
 
         self.assertEqual(actual[0].get('attr1'), 'uri')
         self.assertEqual(actual[0].get('attr2'), 'attr2')
+
+    #TODO NO test can run before serialiable... need to fix
+    def test_z_custom_sources(self):
+        # type: () -> None
+        self.custom_source = TableMetadata('hive', 'gold', 'test_schema3', 'test_table4', 'test_table4', [
+            ColumnMetadata('test_id1', 'description of test_table1', 'bigint', 0, description_source="custom"),
+            ColumnMetadata('test_id2', 'description of test_id2', 'bigint', 1),
+            ColumnMetadata('is_active', None, 'boolean', 2),
+            ColumnMetadata('source', 'description of source', 'varchar', 3),
+            ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
+            ColumnMetadata('ds', None, 'varchar', 5)], is_view=False,
+                                             description_editable=False, description_source="custom",
+                                             description_order=2)
+
+        node_row = self.custom_source.next_node()
+        actual = []
+        while node_row:
+            actual.append(node_row)
+            node_row = self.custom_source.next_node()
+        expected = {'LABEL': 'Programmatic_Description', 'KEY': 'hive://gold.test_schema3/test_table4/_description/custom',
+                    'description_source': 'custom', 'description': 'test_table4', 'description_order:UNQUOTED': 2,
+                    'description_editable:UNQUOTED': False}
+        self.assertEqual(actual[1], expected)
+        expected2 = {'LABEL': 'Programmatic_Description', 'KEY': 'hive://gold.test_schema3/test_table4/test_id1/_description/custom',
+                    'description_source': 'custom', 'description': 'description of test_table1', 'description_order:UNQUOTED': 0,
+                    'description_editable:UNQUOTED': False}
+        self.assertEqual(actual[3], expected2)
 
     def test_tags_field(self):
         # type: () -> None

--- a/tests/unit/models/test_table_metadata.py
+++ b/tests/unit/models/test_table_metadata.py
@@ -31,28 +31,28 @@ class TestTableMetadata(unittest.TestCase):
             {'name': 'test_table1', 'KEY': 'hive://gold.test_schema1/test_table1', 'LABEL': 'Table',
              'is_view:UNQUOTED': False},
             {'description': 'test_table1', 'KEY': 'hive://gold.test_schema1/test_table1/_description',
-             'LABEL': 'Description', 'description_editable:UNQUOTED': True, 'description_source': 'description'},
+             'LABEL': 'Description', 'description_source': 'description'},
             {'sort_order:UNQUOTED': 0, 'type': 'bigint', 'name': 'test_id1',
              'KEY': 'hive://gold.test_schema1/test_table1/test_id1', 'LABEL': 'Column'},
             {'description': 'description of test_table1',
              'KEY': 'hive://gold.test_schema1/test_table1/test_id1/_description', 'LABEL': 'Description',
-             'description_editable:UNQUOTED': True, 'description_source': 'description'},
+             'description_source': 'description'},
             {'sort_order:UNQUOTED': 1, 'type': 'bigint', 'name': 'test_id2',
              'KEY': 'hive://gold.test_schema1/test_table1/test_id2', 'LABEL': 'Column'},
             {'description': 'description of test_id2',
              'KEY': 'hive://gold.test_schema1/test_table1/test_id2/_description',
-             'LABEL': 'Description', 'description_editable:UNQUOTED': True, 'description_source': 'description'},
+             'LABEL': 'Description', 'description_source': 'description'},
             {'sort_order:UNQUOTED': 2, 'type': 'boolean', 'name': 'is_active',
              'KEY': 'hive://gold.test_schema1/test_table1/is_active', 'LABEL': 'Column'},
             {'sort_order:UNQUOTED': 3, 'type': 'varchar', 'name': 'source',
              'KEY': 'hive://gold.test_schema1/test_table1/source', 'LABEL': 'Column'},
             {'description': 'description of source', 'KEY': 'hive://gold.test_schema1/test_table1/source/_description',
-             'LABEL': 'Description', 'description_editable:UNQUOTED': True, 'description_source': 'description'},
+             'LABEL': 'Description', 'description_source': 'description'},
             {'sort_order:UNQUOTED': 4, 'type': 'timestamp', 'name': 'etl_created_at',
              'KEY': 'hive://gold.test_schema1/test_table1/etl_created_at', 'LABEL': 'Column'},
             {'description': 'description of etl_created_at',
              'KEY': 'hive://gold.test_schema1/test_table1/etl_created_at/_description', 'LABEL': 'Description',
-             'description_editable:UNQUOTED': True, 'description_source': 'description'},
+             'description_source': 'description'},
             {'sort_order:UNQUOTED': 5, 'type': 'varchar', 'name': 'ds',
              'KEY': 'hive://gold.test_schema1/test_table1/ds', 'LABEL': 'Column'}
         ]
@@ -167,8 +167,7 @@ class TestTableMetadata(unittest.TestCase):
             ColumnMetadata('is_active', None, 'boolean', 2),
             ColumnMetadata('source', 'description of source', 'varchar', 3),
             ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
-            ColumnMetadata('ds', None, 'varchar', 5)], is_view=False,
-            description_editable=False, description_source="custom")
+            ColumnMetadata('ds', None, 'varchar', 5)], is_view=False, description_source="custom")
 
         node_row = self.custom_source.next_node()
         actual = []
@@ -176,9 +175,8 @@ class TestTableMetadata(unittest.TestCase):
             actual.append(node_row)
             node_row = self.custom_source.next_node()
         expected = {'LABEL': 'Programmatic_Description',
-                    'KEY': 'hive://gold.test_schema3/test_table4/_description/custom',
-                    'description_source': 'custom', 'description': 'test_table4',
-                    'description_editable:UNQUOTED': False}
+                    'KEY': 'hive://gold.test_schema3/test_table4/_custom_description',
+                    'description_source': 'custom', 'description': 'test_table4'}
         self.assertEqual(actual[1], expected)
 
     def test_tags_field(self):


### PR DESCRIPTION
### Summary of Changes

Issue: https://github.com/lyft/amundsen/issues/147

Goal: To add a new node to the data model called "ProgrammaticDescription" which allows for an arbitrary number of descriptions that would be populated programmatically. This would simplify the process of allowing different data feeds that are company specific or that require huge blocks of text without having to give up the ability for users to edit the table description.

At this time, this was only introduced for tables. Likely there is no need for this for columns as there is already a similar concept "column stats".

This set of changes does not include these nodes in search, I have another branch with search changes that I will put up for MR after this first set of MR's are approved.

There are other MRs for other services here:
https://github.com/lyft/amundsencommon/pull/18
https://github.com/lyft/amundsenmetadatalibrary/pull/104
https://github.com/lyft/amundsenfrontendlibrary/pull/381

### Tests

I added and updated test_table_metadata to account for these new nodes.
I modified any tests that dealt with descriptions as part of TableMetadata directly.

### Documentation

I updated sample_data_loader and the sample data with these new examples.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`


