### PR TITLE
escaping backslashes in neo4j publisher

### DIFF
--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -382,7 +382,7 @@ ON MATCH SET {update_prop_body}""".format(create_prop_body=create_prop_body,
             # if isinstance(str, v):
             v = v.replace('\'', "\\'")
             # escape backslash for Cypher query
-            v = v.replace("\\", "\\\\")
+            v = v.replace("\\", "\\")
 
             if k.endswith(UNQUOTED_SUFFIX):
                 k = k[:-len(UNQUOTED_SUFFIX)]

--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -381,6 +381,8 @@ ON MATCH SET {update_prop_body}""".format(create_prop_body=create_prop_body,
             # escape quote for Cypher query
             # if isinstance(str, v):
             v = v.replace('\'', "\\'")
+            # escape backslash for Cypher query
+            v = v.replace("\\", "\\\\")
 
             if k.endswith(UNQUOTED_SUFFIX):
                 k = k[:-len(UNQUOTED_SUFFIX)]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '1.6.1'
+__version__ = '1.6.2'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')


### PR DESCRIPTION
### Summary of Changes

We have a table with a description of `¯\_(ツ)_/¯` and neo4j doesn't like that backslash.

This will escape backslashes.

### Tests

There isn't a test for escaping quotes and I am not sure what the best way to write that test would be.

### Documentation

I believe this behavior is expected and shouldn't need documentation. 

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
