### PR TITLE
Patch to fix backward incompatible issue on table metadata

### DIFF
--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -9,6 +9,9 @@ from databuilder.models.neo4j_csv_serde import (
 from databuilder.publisher.neo4j_csv_publisher import UNQUOTED_SUFFIX
 
 
+DESCRIPTION_NODE_LABEL_VAL = 'Description'
+DESCRIPTION_NODE_LABEL = DESCRIPTION_NODE_LABEL_VAL
+
 class TagMetadata(Neo4jCsvSerializable):
     TAG_NODE_LABEL = 'Tag'
     TAG_KEY_FORMAT = '{tag}'
@@ -58,7 +61,7 @@ class TagMetadata(Neo4jCsvSerializable):
 
 
 class DescriptionMetadata:
-    DESCRIPTION_NODE_LABEL = 'Description'
+    DESCRIPTION_NODE_LABEL = DESCRIPTION_NODE_LABEL_VAL
     PROGRAMMATIC_DESCRIPTION_NODE_LABEL = 'Programmatic_Description'
     DESCRIPTION_KEY_FORMAT = '{description}'
     DESCRIPTION_TEXT = 'description'

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -12,6 +12,7 @@ from databuilder.publisher.neo4j_csv_publisher import UNQUOTED_SUFFIX
 DESCRIPTION_NODE_LABEL_VAL = 'Description'
 DESCRIPTION_NODE_LABEL = DESCRIPTION_NODE_LABEL_VAL
 
+
 class TagMetadata(Neo4jCsvSerializable):
     TAG_NODE_LABEL = 'Tag'
     TAG_KEY_FORMAT = '{tag}'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '1.6.1'
+__version__ = '1.6.2'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')


### PR DESCRIPTION
### Summary of Changes

Constant `DESCRIPTION_NODE_LABEL` previously available changed location by [PR](https://github.com/lyft/amundsendatabuilder/pull/187) This PR is to make it available again.

### Tests

Integration tested

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
