### PR TITLE
Fix broken HiveTableMetadataExtractor.

### DIFF
--- a/databuilder/extractor/hive_table_metadata_extractor.py
+++ b/databuilder/extractor/hive_table_metadata_extractor.py
@@ -27,7 +27,7 @@ class HiveTableMetadataExtractor(Extractor):
     # Using UNION to combine above two statements and order by table & partition identifier.
     SQL_STATEMENT = """
     SELECT source.* FROM
-    (SELECT t.TBL_ID, d.NAME as schema_name, t.TBL_NAME name, t.TBL_TYPE, tp.PARAM_VALUE as description,
+    (SELECT t.TBL_ID, d.NAME as `schema`, t.TBL_NAME name, t.TBL_TYPE, tp.PARAM_VALUE as description,
            p.PKEY_NAME as col_name, p.INTEGER_IDX as col_sort_order,
            p.PKEY_TYPE as col_type, p.PKEY_COMMENT as col_description, 1 as "is_partition_col"
     FROM TBLS t
@@ -36,7 +36,7 @@ class HiveTableMetadataExtractor(Extractor):
     LEFT JOIN TABLE_PARAMS tp ON (t.TBL_ID = tp.TBL_ID AND tp.PARAM_KEY='comment')
     {where_clause_suffix}
     UNION
-    SELECT t.TBL_ID, d.NAME as schema_name, t.TBL_NAME name, t.TBL_TYPE, tp.PARAM_VALUE as description,
+    SELECT t.TBL_ID, d.NAME as `schema`, t.TBL_NAME name, t.TBL_TYPE, tp.PARAM_VALUE as description,
            c.COLUMN_NAME as col_name, c.INTEGER_IDX as col_sort_order,
            c.TYPE_NAME as col_type, c.COMMENT as col_description, 0 as "is_partition_col"
     FROM TBLS t
@@ -101,7 +101,7 @@ class HiveTableMetadataExtractor(Extractor):
                                               row['col_type'], row['col_sort_order']))
 
             yield TableMetadata('hive', self._cluster,
-                                last_row['schema_name'],
+                                last_row['schema'],
                                 last_row['name'],
                                 last_row['description'],
                                 columns)
@@ -125,6 +125,6 @@ class HiveTableMetadataExtractor(Extractor):
         :return:
         """
         if row:
-            return TableKey(schema=row['schema_name'], table_name=row['name'])
+            return TableKey(schema=row['schema'], table_name=row['name'])
 
         return None

--- a/databuilder/extractor/hive_table_metadata_extractor.py
+++ b/databuilder/extractor/hive_table_metadata_extractor.py
@@ -27,7 +27,7 @@ class HiveTableMetadataExtractor(Extractor):
     # Using UNION to combine above two statements and order by table & partition identifier.
     SQL_STATEMENT = """
     SELECT source.* FROM
-    (SELECT t.TBL_ID, d.NAME as schema, t.TBL_NAME name, t.TBL_TYPE, tp.PARAM_VALUE as description,
+    (SELECT t.TBL_ID, d.NAME as schema_name, t.TBL_NAME name, t.TBL_TYPE, tp.PARAM_VALUE as description,
            p.PKEY_NAME as col_name, p.INTEGER_IDX as col_sort_order,
            p.PKEY_TYPE as col_type, p.PKEY_COMMENT as col_description, 1 as "is_partition_col"
     FROM TBLS t
@@ -36,7 +36,7 @@ class HiveTableMetadataExtractor(Extractor):
     LEFT JOIN TABLE_PARAMS tp ON (t.TBL_ID = tp.TBL_ID AND tp.PARAM_KEY='comment')
     {where_clause_suffix}
     UNION
-    SELECT t.TBL_ID, d.NAME as schema, t.TBL_NAME name, t.TBL_TYPE, tp.PARAM_VALUE as description,
+    SELECT t.TBL_ID, d.NAME as schema_name, t.TBL_NAME name, t.TBL_TYPE, tp.PARAM_VALUE as description,
            c.COLUMN_NAME as col_name, c.INTEGER_IDX as col_sort_order,
            c.TYPE_NAME as col_type, c.COMMENT as col_description, 0 as "is_partition_col"
     FROM TBLS t
@@ -101,7 +101,7 @@ class HiveTableMetadataExtractor(Extractor):
                                               row['col_type'], row['col_sort_order']))
 
             yield TableMetadata('hive', self._cluster,
-                                last_row['schema'],
+                                last_row['schema_name'],
                                 last_row['name'],
                                 last_row['description'],
                                 columns)
@@ -125,6 +125,6 @@ class HiveTableMetadataExtractor(Extractor):
         :return:
         """
         if row:
-            return TableKey(schema=row['schema'], table_name=row['name'])
+            return TableKey(schema=row['schema_name'], table_name=row['name'])
 
         return None

--- a/databuilder/extractor/presto_view_metadata_extractor.py
+++ b/databuilder/extractor/presto_view_metadata_extractor.py
@@ -22,7 +22,7 @@ class PrestoViewMetadataExtractor(Extractor):
     # SQL statement to extract View metadata
     # {where_clause_suffix} could be used to filter schemas
     SQL_STATEMENT = """
-    SELECT t.TBL_ID, d.NAME as schema, t.TBL_NAME name, t.TBL_TYPE, t.VIEW_ORIGINAL_TEXT as view_original_text
+    SELECT t.TBL_ID, d.NAME as `schema`, t.TBL_NAME name, t.TBL_TYPE, t.VIEW_ORIGINAL_TEXT as view_original_text
     FROM TBLS t
     JOIN DBS d ON t.DB_ID = d.DB_ID
     WHERE t.VIEW_EXPANDED_TEXT = '/* Presto View */'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/tests/unit/extractor/test_hive_table_metadata_extractor.py
+++ b/tests/unit/extractor/test_hive_table_metadata_extractor.py
@@ -40,7 +40,7 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
             mock_connection.return_value = connection
             sql_execute = MagicMock()
             connection.execute = sql_execute
-            table = {'schema': 'test_schema',
+            table = {'schema_name': 'test_schema',
                      'name': 'test_table',
                      'description': 'a table for testing'}
 
@@ -97,15 +97,15 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
             mock_connection.return_value = connection
             sql_execute = MagicMock()
             connection.execute = sql_execute
-            table = {'schema': 'test_schema1',
+            table = {'schema_name': 'test_schema1',
                      'name': 'test_table1',
                      'description': 'test table 1'}
 
-            table1 = {'schema': 'test_schema1',
+            table1 = {'schema_name': 'test_schema1',
                       'name': 'test_table2',
                       'description': 'test table 2'}
 
-            table2 = {'schema': 'test_schema2',
+            table2 = {'schema_name': 'test_schema2',
                       'name': 'test_table3',
                       'description': 'test table 3'}
 

--- a/tests/unit/extractor/test_hive_table_metadata_extractor.py
+++ b/tests/unit/extractor/test_hive_table_metadata_extractor.py
@@ -40,7 +40,7 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
             mock_connection.return_value = connection
             sql_execute = MagicMock()
             connection.execute = sql_execute
-            table = {'schema_name': 'test_schema',
+            table = {'schema': 'test_schema',
                      'name': 'test_table',
                      'description': 'a table for testing'}
 
@@ -97,15 +97,15 @@ class TestHiveTableMetadataExtractor(unittest.TestCase):
             mock_connection.return_value = connection
             sql_execute = MagicMock()
             connection.execute = sql_execute
-            table = {'schema_name': 'test_schema1',
+            table = {'schema': 'test_schema1',
                      'name': 'test_table1',
                      'description': 'test table 1'}
 
-            table1 = {'schema_name': 'test_schema1',
+            table1 = {'schema': 'test_schema1',
                       'name': 'test_table2',
                       'description': 'test table 2'}
 
-            table2 = {'schema_name': 'test_schema2',
+            table2 = {'schema': 'test_schema2',
                       'name': 'test_table3',
                       'description': 'test table 3'}
 


### PR DESCRIPTION
### Summary of Changes

The recent refactor to 2.0.0 causes the HiveTableMetadataExtractor to fail:
https://github.com/lyft/amundsendatabuilder/commit/dac8110d333f6dbc0e0f40c8d9c5e152ffa43775

It appears to be because `schema` is a reserved keyword in my Hive metastore.  

### Tests

Modified `test_hive_table_metadata_extractor.py`.

### Documentation

None.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
