### PR TITLE
Add badges to Neo4jExtractor and elastic search 

### DIFF
--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -35,7 +35,7 @@ class Neo4jSearchDataExtractor(Extractor):
         REDUCE(sum_r = 0, r in COLLECT(DISTINCT read)| sum_r + r.read_count) AS total_usage,
         COUNT(DISTINCT user.email) as unique_usage,
         COLLECT(DISTINCT tags.key) as tags,
-        COLLECT(DISTINCT badges.key) as badge_names
+        COLLECT(DISTINCT badges.key) as badges
         ORDER BY table.name;
         """
     )

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -24,7 +24,7 @@ class Neo4jSearchDataExtractor(Extractor):
         OPTIONAL MATCH (table)-[read:READ_BY]->(user:User)
         OPTIONAL MATCH (table)-[:COLUMN]->(cols:Column)
         OPTIONAL MATCH (cols)-[:DESCRIPTION]->(col_description:Description)
-        OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag)
+        OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag) WHERE tags.tag_type='default'
         OPTIONAL MATCH (table)-[:TAGGED_BY]->(badges:Tag) WHERE tags.tag_type='badge'
         OPTIONAL MATCH (table)-[:LAST_UPDATED_AT]->(time_stamp:Timestamp)
         RETURN db.name as database, cluster.name AS cluster, schema.name AS schema,

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -25,7 +25,7 @@ class Neo4jSearchDataExtractor(Extractor):
         OPTIONAL MATCH (table)-[:COLUMN]->(cols:Column)
         OPTIONAL MATCH (cols)-[:DESCRIPTION]->(col_description:Description)
         OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag)
-        OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag) WHERE tags.tag_type='badge'
+        OPTIONAL MATCH (table)-[:TAGGED_BY]->(badges:Tag) WHERE tags.tag_type='badge'
         OPTIONAL MATCH (table)-[:LAST_UPDATED_AT]->(time_stamp:Timestamp)
         RETURN db.name as database, cluster.name AS cluster, schema.name AS schema,
         table.name AS name, table.key AS key, table_description.description AS description,

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -24,7 +24,7 @@ class Neo4jSearchDataExtractor(Extractor):
         OPTIONAL MATCH (table)-[read:READ_BY]->(user:User)
         OPTIONAL MATCH (table)-[:COLUMN]->(cols:Column)
         OPTIONAL MATCH (cols)-[:DESCRIPTION]->(col_description:Description)
-        OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag) WHERE tags.tag_type='default'
+        OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag)
         OPTIONAL MATCH (table)-[:TAGGED_BY]->(badges:Tag) WHERE badges.tag_type='badge'
         OPTIONAL MATCH (table)-[:LAST_UPDATED_AT]->(time_stamp:Timestamp)
         RETURN db.name as database, cluster.name AS cluster, schema.name AS schema,

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -24,7 +24,7 @@ class Neo4jSearchDataExtractor(Extractor):
         OPTIONAL MATCH (table)-[read:READ_BY]->(user:User)
         OPTIONAL MATCH (table)-[:COLUMN]->(cols:Column)
         OPTIONAL MATCH (cols)-[:DESCRIPTION]->(col_description:Description)
-        OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag)
+        OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag) WHERE tags.tag_type='default'
         OPTIONAL MATCH (table)-[:TAGGED_BY]->(badges:Tag) WHERE badges.tag_type='badge'
         OPTIONAL MATCH (table)-[:LAST_UPDATED_AT]->(time_stamp:Timestamp)
         RETURN db.name as database, cluster.name AS cluster, schema.name AS schema,

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -25,6 +25,7 @@ class Neo4jSearchDataExtractor(Extractor):
         OPTIONAL MATCH (table)-[:COLUMN]->(cols:Column)
         OPTIONAL MATCH (cols)-[:DESCRIPTION]->(col_description:Description)
         OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag)
+        OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag) WHERE tags.tag_type='badge'
         OPTIONAL MATCH (table)-[:LAST_UPDATED_AT]->(time_stamp:Timestamp)
         RETURN db.name as database, cluster.name AS cluster, schema.name AS schema,
         table.name AS name, table.key AS key, table_description.description AS description,
@@ -33,7 +34,8 @@ class Neo4jSearchDataExtractor(Extractor):
         EXTRACT(cd IN COLLECT(DISTINCT col_description)| cd.description) AS column_descriptions,
         REDUCE(sum_r = 0, r in COLLECT(DISTINCT read)| sum_r + r.read_count) AS total_usage,
         COUNT(DISTINCT user.email) as unique_usage,
-        COLLECT(DISTINCT tags.key) as tags
+        COLLECT(DISTINCT tags.key) as tags,
+        COLLECT(DISTINCT badges.key) as badge_names
         ORDER BY table.name;
         """
     )

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -25,7 +25,7 @@ class Neo4jSearchDataExtractor(Extractor):
         OPTIONAL MATCH (table)-[:COLUMN]->(cols:Column)
         OPTIONAL MATCH (cols)-[:DESCRIPTION]->(col_description:Description)
         OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag) WHERE tags.tag_type='default'
-        OPTIONAL MATCH (table)-[:TAGGED_BY]->(badges:Tag) WHERE tags.tag_type='badge'
+        OPTIONAL MATCH (table)-[:TAGGED_BY]->(badges:Tag) WHERE badges.tag_type='badge'
         OPTIONAL MATCH (table)-[:LAST_UPDATED_AT]->(time_stamp:Timestamp)
         RETURN db.name as database, cluster.name AS cluster, schema.name AS schema,
         table.name AS name, table.key AS key, table_description.description AS description,

--- a/databuilder/models/table_elasticsearch_document.py
+++ b/databuilder/models/table_elasticsearch_document.py
@@ -20,7 +20,7 @@ class TableESDocument(ElasticsearchDocument):
                  total_usage,  # type: int
                  unique_usage,  # type: int
                  tags,  # type: List[str],
-                 badges,  # type: List[str]
+                 badges=None,  # type: Optional[List[str]]
                  display_name=None,  # type: Optional[str]
                  ):
         # type: (...) -> None

--- a/databuilder/models/table_elasticsearch_document.py
+++ b/databuilder/models/table_elasticsearch_document.py
@@ -19,7 +19,8 @@ class TableESDocument(ElasticsearchDocument):
                  column_descriptions,  # type: List[str]
                  total_usage,  # type: int
                  unique_usage,  # type: int
-                 tags,  # type: List[str]
+                 tags,  # type: List[str],
+                 badges,  # type: List[str]
                  display_name=None,  # type: Optional[str]
                  ):
         # type: (...) -> None
@@ -38,3 +39,4 @@ class TableESDocument(ElasticsearchDocument):
         self.unique_usage = unique_usage
         # todo: will include tag_type once we have better understanding from UI flow.
         self.tags = tags
+        self.badges = badges

--- a/databuilder/publisher/elasticsearch_publisher.py
+++ b/databuilder/publisher/elasticsearch_publisher.py
@@ -36,7 +36,7 @@ class ElasticsearchPublisher(Publisher):
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-simple-analyzer.html
     # Standard Analyzer is used for all text fields that don't explicitly specify an analyzer
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-analyzer.html
-    # TODO use amundsencommon for this when this project is updated to py3 
+    # TODO use amundsencommon for this when this project is updated to py3
     DEFAULT_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
         """
         {

--- a/databuilder/publisher/elasticsearch_publisher.py
+++ b/databuilder/publisher/elasticsearch_publisher.py
@@ -1,10 +1,11 @@
 import json
 import logging
-import textwrap
 from typing import List  # noqa: F401
 
 from pyhocon import ConfigTree  # noqa: F401
 from elasticsearch.exceptions import NotFoundError
+from amundsen_common.elastic_search.index_map import TABLE_INDEX_MAP
+
 
 from databuilder.publisher.base_publisher import Publisher
 
@@ -29,95 +30,6 @@ class ElasticsearchPublisher(Publisher):
     ELASTICSEARCH_ALIAS_CONFIG_KEY = 'alias'
     ELASTICSEARCH_MAPPING_CONFIG_KEY = 'mapping'
 
-    # Specifying default mapping for elasticsearch index
-    # Documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
-    # Setting type to "text" for all fields that would be used in search
-    # Using Simple Analyzer to convert all text into search terms
-    # https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-simple-analyzer.html
-    # Standard Analyzer is used for all text fields that don't explicitly specify an analyzer
-    # https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-analyzer.html
-    DEFAULT_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
-        """
-        {
-        "mappings":{
-            "table":{
-              "properties": {
-                "name": {
-                  "type":"text",
-                  "analyzer": "simple",
-                  "fields": {
-                    "raw": {
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "schema": {
-                  "type":"text",
-                  "analyzer": "simple",
-                  "fields": {
-                    "raw": {
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "display_name": {
-                  "type": "keyword"
-                },
-                "last_updated_timestamp": {
-                  "type": "date",
-                  "format": "epoch_second"
-                },
-                "description": {
-                  "type": "text",
-                  "analyzer": "simple"
-                },
-                "column_names": {
-                  "type":"text",
-                  "analyzer": "simple",
-                  "fields": {
-                    "raw": {
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "column_descriptions": {
-                  "type": "text",
-                  "analyzer": "simple"
-                },
-                "tags": {
-                  "type": "keyword"
-                },
-                "badges": {
-                  "type": "keyword"
-                },
-                "cluster": {
-                  "type": "text"
-                },
-                "database": {
-                  "type": "text",
-                  "analyzer": "simple",
-                  "fields": {
-                    "raw": {
-                      "type": "keyword"
-                    }
-                  }
-                },
-                "key": {
-                  "type": "keyword"
-                },
-                "total_usage":{
-                  "type": "long"
-                },
-                "unique_usage": {
-                  "type": "long"
-                }
-              }
-            }
-          }
-        }
-        """
-    )
-
     def __init__(self):
         # type: () -> None
         super(ElasticsearchPublisher, self).__init__()
@@ -135,7 +47,7 @@ class ElasticsearchPublisher(Publisher):
         self.elasticsearch_alias = self.conf.get(ElasticsearchPublisher.ELASTICSEARCH_ALIAS_CONFIG_KEY)
 
         self.elasticsearch_mapping = self.conf.get(ElasticsearchPublisher.ELASTICSEARCH_MAPPING_CONFIG_KEY,
-                                                   ElasticsearchPublisher.DEFAULT_ELASTICSEARCH_INDEX_MAPPING)
+                                                   TABLE_INDEX_MAP)
 
         self.file_handler = open(self.file_path, self.file_mode)
 

--- a/databuilder/publisher/elasticsearch_publisher.py
+++ b/databuilder/publisher/elasticsearch_publisher.py
@@ -87,6 +87,9 @@ class ElasticsearchPublisher(Publisher):
                 "tags": {
                   "type": "keyword"
                 },
+                "badges": {
+                  "type": "keyword"
+                },
                 "cluster": {
                   "type": "text"
                 },

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,6 @@ antlr4-python2-runtime==4.7.1
 statsd==3.2.1
 retrying==1.3.3
 unicodecsv==0.14.1,<1.0
-amundsen-common==0.2.3
 
 httplib2~=0.9.2
 unidecode

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ pytz==2018.4
 antlr4-python2-runtime==4.7.1
 statsd==3.2.1
 retrying==1.3.3
+amundsen-common==0.2.3
 
 
 

--- a/tests/unit/extractor/test_neo4j_extractor.py
+++ b/tests/unit/extractor/test_neo4j_extractor.py
@@ -113,7 +113,7 @@ class TestNeo4jExtractor(unittest.TestCase):
                                total_usage=100,
                                unique_usage=5,
                                tags=['hive'],
-                               badges=['5_min_lag'])
+                               badges=['badge1'])
 
             extractor.results = [result_dict]
             result_obj = extractor.extract()

--- a/tests/unit/extractor/test_neo4j_extractor.py
+++ b/tests/unit/extractor/test_neo4j_extractor.py
@@ -112,7 +112,8 @@ class TestNeo4jExtractor(unittest.TestCase):
                                column_descriptions=['test_description1', 'test_description2', ''],
                                total_usage=100,
                                unique_usage=5,
-                               tags=['hive'])
+                               tags=['hive'],
+                               badges=['5_min_lag'])
 
             extractor.results = [result_dict]
             result_obj = extractor.extract()

--- a/tests/unit/loader/test_file_system_elasticsearch_json_loader.py
+++ b/tests/unit/loader/test_file_system_elasticsearch_json_loader.py
@@ -100,7 +100,8 @@ class TestFSElasticsearchJSONLoader(unittest.TestCase):
                                column_descriptions=['test_comment1', 'test_comment2'],
                                total_usage=10,
                                unique_usage=5,
-                               tags=['test_tag1', 'test_tag2'])
+                               tags=['test_tag1', 'test_tag2'],
+                               badges=['badge1'])
         loader.load(data)
         loader.close()
 
@@ -110,7 +111,7 @@ class TestFSElasticsearchJSONLoader(unittest.TestCase):
              '"column_names": ["test_col1", "test_col2"], "name": "test_table", '
              '"last_updated_timestamp": 123456789, "display_name": "test_schema.test_table", '
              '"description": "test_description", "unique_usage": 5, "total_usage": 10, '
-             '"tags": ["test_tag1", "test_tag2"]}')
+             '"tags": ["test_tag1", "test_tag2"], "badges": ["badge1"]}')
         ]
 
         self._check_results_helper(expected=expected)
@@ -136,7 +137,8 @@ class TestFSElasticsearchJSONLoader(unittest.TestCase):
                                 column_descriptions=['test_comment1', 'test_comment2'],
                                 total_usage=10,
                                 unique_usage=5,
-                                tags=['test_tag1', 'test_tag2'])] * 5
+                                tags=['test_tag1', 'test_tag2'],
+                                badges=['badge1'])] * 5
 
         for d in data:
             loader.load(d)
@@ -148,7 +150,7 @@ class TestFSElasticsearchJSONLoader(unittest.TestCase):
              '"column_names": ["test_col1", "test_col2"], "name": "test_table", '
              '"last_updated_timestamp": 123456789, "display_name": "test_schema.test_table", '
              '"description": "test_description", "unique_usage": 5, "total_usage": 10, '
-             '"tags": ["test_tag1", "test_tag2"]}')
+             '"tags": ["test_tag1", "test_tag2"], "badges": ["badge1"]}')
         ] * 5
 
         self._check_results_helper(expected=expected)

--- a/tests/unit/models/test_table_elasticsearch_document.py
+++ b/tests/unit/models/test_table_elasticsearch_document.py
@@ -23,7 +23,7 @@ class TestTableElasticsearchDocument(unittest.TestCase):
                                    total_usage=100,
                                    unique_usage=10,
                                    tags=['test'],
-                                   badges=['5_min_lag'])
+                                   badges=['badge1'])
 
         expected_document_dict = {"database": "test_database",
                                   "cluster": "test_cluster",
@@ -38,7 +38,7 @@ class TestTableElasticsearchDocument(unittest.TestCase):
                                   "total_usage": 100,
                                   "unique_usage": 10,
                                   "tags": ["test"],
-                                  "badges": ["5_min_lag"]
+                                  "badges": ["badge1"]
                                   }
 
         result = test_obj.to_json()

--- a/tests/unit/models/test_table_elasticsearch_document.py
+++ b/tests/unit/models/test_table_elasticsearch_document.py
@@ -22,7 +22,8 @@ class TestTableElasticsearchDocument(unittest.TestCase):
                                    column_descriptions=['test_description1', 'test_description2'],
                                    total_usage=100,
                                    unique_usage=10,
-                                   tags=['test'])
+                                   tags=['test'],
+                                   badges=['5_min_lag'])
 
         expected_document_dict = {"database": "test_database",
                                   "cluster": "test_cluster",
@@ -36,7 +37,8 @@ class TestTableElasticsearchDocument(unittest.TestCase):
                                   "column_descriptions": ["test_description1", "test_description2"],
                                   "total_usage": 100,
                                   "unique_usage": 10,
-                                  "tags": ["test"]
+                                  "tags": ["test"],
+                                  "badges": ["5_min_lag"]
                                   }
 
         result = test_obj.to_json()

--- a/tests/unit/publisher/test_elasticsearch_publisher.py
+++ b/tests/unit/publisher/test_elasticsearch_publisher.py
@@ -4,6 +4,7 @@ import six
 import unittest
 
 from pyhocon import ConfigFactory
+from amundsen_common.elastic_search.index_map import TABLE_INDEX_MAP
 
 from databuilder import Scoped
 from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
@@ -72,7 +73,7 @@ class TestElasticsearchPublisher(unittest.TestCase):
 
             publisher.publish()
             # ensure indices create endpoint was called
-            default_mapping = ElasticsearchPublisher.DEFAULT_ELASTICSEARCH_INDEX_MAPPING
+            default_mapping = TABLE_INDEX_MAP
             self.mock_es_client.indices.create.assert_called_once_with(index=self.test_es_new_index,
                                                                        body=default_mapping)
 
@@ -109,7 +110,7 @@ class TestElasticsearchPublisher(unittest.TestCase):
 
             publisher.publish()
             # ensure indices create endpoint was called
-            default_mapping = ElasticsearchPublisher.DEFAULT_ELASTICSEARCH_INDEX_MAPPING
+            default_mapping = TABLE_INDEX_MAP
             self.mock_es_client.indices.create.assert_called_once_with(index=self.test_es_new_index,
                                                                        body=default_mapping)
 

--- a/tests/unit/publisher/test_elasticsearch_publisher.py
+++ b/tests/unit/publisher/test_elasticsearch_publisher.py
@@ -4,7 +4,6 @@ import six
 import unittest
 
 from pyhocon import ConfigFactory
-from amundsen_common.elastic_search.index_map import TABLE_INDEX_MAP
 
 from databuilder import Scoped
 from databuilder.publisher.elasticsearch_publisher import ElasticsearchPublisher
@@ -73,7 +72,7 @@ class TestElasticsearchPublisher(unittest.TestCase):
 
             publisher.publish()
             # ensure indices create endpoint was called
-            default_mapping = TABLE_INDEX_MAP
+            default_mapping = ElasticsearchPublisher.DEFAULT_ELASTICSEARCH_INDEX_MAPPING
             self.mock_es_client.indices.create.assert_called_once_with(index=self.test_es_new_index,
                                                                        body=default_mapping)
 
@@ -110,7 +109,7 @@ class TestElasticsearchPublisher(unittest.TestCase):
 
             publisher.publish()
             # ensure indices create endpoint was called
-            default_mapping = TABLE_INDEX_MAP
+            default_mapping = ElasticsearchPublisher.DEFAULT_ELASTICSEARCH_INDEX_MAPPING
             self.mock_es_client.indices.create.assert_called_once_with(index=self.test_es_new_index,
                                                                        body=default_mapping)
 


### PR DESCRIPTION
### Summary of Changes

Adds badges to elastic search results so that they can be surfaced by the search service. End goal is to allow badges to be visible on search results page. 

### Tests
Modified tests to include badges as a field for tables from elastic search 

### Documentation
N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
