### PR TITLE
Update neo4j search extraction query to query less rows

### DIFF
--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -24,8 +24,12 @@ class Neo4jSearchDataExtractor(Extractor):
         OPTIONAL MATCH (table)-[read:READ_BY]->(user:User)
         OPTIONAL MATCH (table)-[:COLUMN]->(cols:Column)
         OPTIONAL MATCH (cols)-[:DESCRIPTION]->(col_description:Description)
-        OPTIONAL MATCH (table)-[:TAGGED_BY]->(tags:Tag) WHERE tags.tag_type='default'
-        OPTIONAL MATCH (table)-[:TAGGED_BY]->(badges:Tag) WHERE badges.tag_type='badge'
+        OPTIONAL MATCH (table)-[:TAGGED_BY]->(table_tags:Tag) 
+        WITH table_tags as tags, db, cluster, schema, table, table_description, cols, col_description, user, read
+        WHERE table_tags.tag_type = "default" or table_tags is null
+        OPTIONAL MATCH (table)-[:TAGGED_BY]->(table_tags:Tag) 
+        WITH table_tags as badges, tags, db, cluster, schema, table, table_description, cols, col_description, user, read
+        WHERE table_tags.tag_type = "badge" or table_tags is null
         OPTIONAL MATCH (table)-[:LAST_UPDATED_AT]->(time_stamp:Timestamp)
         RETURN db.name as database, cluster.name AS cluster, schema.name AS schema,
         table.name AS name, table.key AS key, table_description.description AS description,
@@ -34,8 +38,7 @@ class Neo4jSearchDataExtractor(Extractor):
         EXTRACT(cd IN COLLECT(DISTINCT col_description)| cd.description) AS column_descriptions,
         REDUCE(sum_r = 0, r in COLLECT(DISTINCT read)| sum_r + r.read_count) AS total_usage,
         COUNT(DISTINCT user.email) as unique_usage,
-        COLLECT(DISTINCT tags.key) as tags,
-        COLLECT(DISTINCT badges.key) as badges
+        COLLECT(DISTINCT tags.key) as tags
         ORDER BY table.name;
         """
     )

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -28,7 +28,8 @@ class Neo4jSearchDataExtractor(Extractor):
         WITH table_tags as tags, db, cluster, schema, table, table_description, cols, col_description, user, read
         WHERE table_tags.tag_type = "default" or table_tags is null
         OPTIONAL MATCH (table)-[:TAGGED_BY]->(table_tags:Tag) 
-        WITH table_tags as badges, tags, db, cluster, schema, table, table_description, cols, col_description, user, read
+        WITH table_tags as badges, tags, db, cluster, schema, table, table_description, cols, col_description, 
+        user, read
         WHERE table_tags.tag_type = "badge" or table_tags is null
         OPTIONAL MATCH (table)-[:LAST_UPDATED_AT]->(time_stamp:Timestamp)
         RETURN db.name as database, cluster.name AS cluster, schema.name AS schema,

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -38,7 +38,8 @@ class Neo4jSearchDataExtractor(Extractor):
         EXTRACT(cd IN COLLECT(DISTINCT col_description)| cd.description) AS column_descriptions,
         REDUCE(sum_r = 0, r in COLLECT(DISTINCT read)| sum_r + r.read_count) AS total_usage,
         COUNT(DISTINCT user.email) as unique_usage,
-        COLLECT(DISTINCT tags.key) as tags
+        COLLECT(DISTINCT tags.key) as tags, 
+        COLLECT(DISTINCT badges.key) as badges
         ORDER BY table.name;
         """
     )


### PR DESCRIPTION
### Summary of Changes
Adds WITH clauses to the tag selects. We had issues with the current extraction query timing out occasionally in production. I see in staging that this ends up hitting about the db about half as often, but the time to run is about the same so I'm not sure this will fix the issue effectively. 

### Tests
N/A

### Documentation
N/A
### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
