### PR TITLE
Add Dashboard Table model

### DIFF
--- a/databuilder/models/dashboard/dashboard_table.py
+++ b/databuilder/models/dashboard/dashboard_table.py
@@ -3,7 +3,7 @@ import re
 
 from typing import Optional, Dict, Any, List, Union, Iterator  # noqa: F401
 
-from databuilder.models.dashboard_metadata import DashboardMetadata
+from databuilder.models.dashboard.dashboard_metadata import DashboardMetadata
 from databuilder.models.neo4j_csv_serde import (
     Neo4jCsvSerializable, RELATION_START_KEY, RELATION_END_KEY, RELATION_START_LABEL,
     RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE)

--- a/databuilder/models/dashboard/dashboard_table.py
+++ b/databuilder/models/dashboard/dashboard_table.py
@@ -1,0 +1,85 @@
+import logging
+import re
+
+from typing import Optional, Dict, Any, List, Union, Iterator  # noqa: F401
+
+from databuilder.models.dashboard_metadata import DashboardMetadata
+from databuilder.models.neo4j_csv_serde import (
+    Neo4jCsvSerializable, RELATION_START_KEY, RELATION_END_KEY, RELATION_START_LABEL,
+    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE)
+from databuilder.models.table_metadata import TableMetadata
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DashboardTable(Neo4jCsvSerializable):
+    """
+    A model that link Dashboard with the tables used in various charts of the dashboard.
+    Note that it does not create new dashboard, table as it has insufficient information but it builds relation
+    between Tables and Dashboard
+    """
+
+    DASHBOARD_TABLE_RELATION_TYPE = 'DASHBOARD_OF'
+    TABLE_DASHBOARD_RELATION_TYPE = 'TABLE_OF'
+
+    def __init__(self,
+                 dashboard_group_id,  # type: str
+                 dashboard_id,  # type: str
+                 table_ids,  # type: List[str]
+                 product='',  # type: Optional[str]
+                 cluster='gold',  # type: str
+                 **kwargs
+                 ):
+        self._dashboard_group_id = dashboard_group_id
+        self._dashboard_id = dashboard_id
+        # A list of tables uri used in the dashboard
+        self._table_ids = table_ids
+        self._product = product
+        self._cluster = cluster
+
+        self._relation_iterator = self._create_relation_iterator()
+
+    def create_next_node(self):
+        # type: () -> Union[Dict[str, Any], None]
+        return None
+
+    def create_next_relation(self):
+        # type: () -> Union[Dict[str, Any], None]
+        try:
+            return next(self._relation_iterator)
+        except StopIteration:
+            return None
+
+    def _create_relation_iterator(self):
+        # type: () -> Optional[None, Iterator[[Dict[str, Any]]]]
+        for table_id in self._table_ids:
+            m = re.match('(\w+)://(\w+)\.(\w+)\/(\w+)', table_id)
+            if m:
+                yield {
+                    RELATION_START_LABEL: DashboardMetadata.DASHBOARD_NODE_LABEL,
+                    RELATION_END_LABEL: TableMetadata.TABLE_NODE_LABEL,
+                    RELATION_START_KEY: DashboardMetadata.DASHBOARD_KEY_FORMAT.format(
+                        product=self._product,
+                        cluster=self._cluster,
+                        dashboard_group=self._dashboard_group_id,
+                        dashboard_name=self._dashboard_id
+                    ),
+                    RELATION_END_KEY: TableMetadata.TABLE_KEY_FORMAT.format(
+                        db=m.group(1),
+                        cluster=m.group(2),
+                        schema=m.group(3),
+                        tbl=m.group(4)
+                    ),
+                    RELATION_TYPE: DashboardTable.DASHBOARD_TABLE_RELATION_TYPE,
+                    RELATION_REVERSE_TYPE: DashboardTable.TABLE_DASHBOARD_RELATION_TYPE
+                }
+
+    def __repr__(self):
+        return 'DashboardTable({!r}, {!r}, {!r}, {!r}, ({!r}))'.format(
+            self._dashboard_group_id,
+            self._dashboard_id,
+            self._product,
+            self._cluster,
+            ','.join(self._table_ids),
+        )

--- a/databuilder/models/dashboard/dashboard_table.py
+++ b/databuilder/models/dashboard/dashboard_table.py
@@ -20,8 +20,8 @@ class DashboardTable(Neo4jCsvSerializable):
     between Tables and Dashboard
     """
 
-    DASHBOARD_TABLE_RELATION_TYPE = 'DASHBOARD_OF'
-    TABLE_DASHBOARD_RELATION_TYPE = 'TABLE_OF'
+    DASHBOARD_TABLE_RELATION_TYPE = 'DASHBOARD_WITH_TABLE'
+    TABLE_DASHBOARD_RELATION_TYPE = 'TABLE_OF_DASHBOARD'
 
     def __init__(self,
                  dashboard_group_id,  # type: str

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '2.3.1'
+__version__ = '2.3.2'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/tests/unit/models/dashboard/test_dashboard_table.py
+++ b/tests/unit/models/dashboard/test_dashboard_table.py
@@ -1,0 +1,31 @@
+import unittest
+
+from databuilder.models.dashboard.dashboard_table import DashboardTable
+from databuilder.models.neo4j_csv_serde import RELATION_START_KEY, RELATION_START_LABEL, RELATION_END_KEY, \
+    RELATION_END_LABEL, RELATION_TYPE, RELATION_REVERSE_TYPE
+
+
+class TestDashboardTable(unittest.TestCase):
+
+    def test_dashboard_table_nodes(self):
+        # type: () -> None
+        dashboard_table = DashboardTable(table_ids=['hive://gold.schema/table1', 'hive://gold.schema/table2'],
+                                         cluster='cluster_id', product='product_id',
+                                         dashboard_id='dashboard_id', dashboard_group_id='dashboard_group_id')
+
+        actual = dashboard_table.create_next_node()
+        self.assertIsNone(actual)
+
+    def test_dashboard_table_relations(self):
+        # type: () -> None
+        dashboard_table = DashboardTable(table_ids=['hive://gold.schema/table1'],
+                                         cluster='cluster_id', product='product_id',
+                                         dashboard_id='dashboard_id', dashboard_group_id='dashboard_group_id')
+
+        actual = dashboard_table.create_next_relation()
+        expected = {RELATION_END_KEY: 'hive://gold.schema/table1', RELATION_START_LABEL: 'Dashboard',
+                    RELATION_END_LABEL: 'Table',
+                    RELATION_START_KEY: 'product_id_dashboard://cluster_id.dashboard_group_id/dashboard_id',
+                    RELATION_TYPE: 'DASHBOARD_OF',
+                    RELATION_REVERSE_TYPE: 'TABLE_OF'}
+        self.assertDictEqual(actual, expected)

--- a/tests/unit/models/dashboard/test_dashboard_table.py
+++ b/tests/unit/models/dashboard/test_dashboard_table.py
@@ -26,6 +26,6 @@ class TestDashboardTable(unittest.TestCase):
         expected = {RELATION_END_KEY: 'hive://gold.schema/table1', RELATION_START_LABEL: 'Dashboard',
                     RELATION_END_LABEL: 'Table',
                     RELATION_START_KEY: 'product_id_dashboard://cluster_id.dashboard_group_id/dashboard_id',
-                    RELATION_TYPE: 'DASHBOARD_OF',
-                    RELATION_REVERSE_TYPE: 'TABLE_OF'}
+                    RELATION_TYPE: 'DASHBOARD_WITH_TABLE',
+                    RELATION_REVERSE_TYPE: 'TABLE_OF_DASHBOARD'}
         self.assertDictEqual(actual, expected)


### PR DESCRIPTION
### Summary of Changes

Add a model to capture dashboard<->tables lineage. The model only creates relationship and not nodes.
And it is a 1:N between dashboard and tables.

There are a few ways to get dashboard and those tables used by the dashboard:
-  API from the product(e.g mode analytics doesn't, looker, tableau, even superset) that directly provides which tables used by the charts of the given dashboard.
- API that provides sql that powers the charts of the given dashboard which requires user to parse the sql to get the table name.
- An internal table to store this metadata. At Lyft whenever a query was run in mode dashboard, it will get captured in presto query log which parsed and stored the table id for a given dashboard. This is similar to the second case. 

Hence Amundsen only provides the model and allows different users to get this part of lineage info.

### Tests

Added

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
