### PR TITLE
Slight change from title to role name

### DIFF
--- a/databuilder/models/user.py
+++ b/databuilder/models/user.py
@@ -25,7 +25,7 @@ class User(Neo4jCsvSerializable):
     USER_NODE_SLACK_ID = 'slack_id'
     USER_NODE_IS_ACTIVE = 'is_active{}'.format(UNQUOTED_SUFFIX)  # bool value needs to be unquoted when publish to neo4j
     USER_NODE_UPDATED_AT = 'updated_at'
-    USER_NODE_TITLE = 'title'
+    USER_NODE_ROLE_NAME = 'role_name'
 
     USER_MANAGER_RELATION_TYPE = 'MANAGE_BY'
     MANAGER_USER_RELATION_TYPE = 'MANAGE'
@@ -42,7 +42,7 @@ class User(Neo4jCsvSerializable):
                  slack_id='',  # type: str
                  is_active=True,  # type: bool
                  updated_at=0,  # type: int
-                 title='',  # type: str
+                 role_name='',  # type: str
                  **kwargs  # type: Dict
                  ):
         # type: (...) -> None
@@ -61,7 +61,7 @@ class User(Neo4jCsvSerializable):
         :param updated_at: everytime we update the node, we will push the timestamp.
                            then we will have a cron job to update the ex-employee nodes based on
                            the case if this timestamp hasn't been updated for two weeks.
-        :param title: the title of the user (e.g swe)
+        :param role_name: the role_name of the user (e.g swe)
         :param kwargs: Any K/V attributes we want to update the
         """
         self.first_name = first_name
@@ -78,7 +78,7 @@ class User(Neo4jCsvSerializable):
         self.slack_id = slack_id
         self.is_active = is_active
         self.updated_at = updated_at
-        self.title = title
+        self.role_name = role_name
         self.attrs = None
         if kwargs:
             self.attrs = copy.deepcopy(kwargs)
@@ -133,7 +133,7 @@ class User(Neo4jCsvSerializable):
         result_node[User.USER_NODE_EMPLOYEE_TYPE] = self.employee_type if self.employee_type else ''
         result_node[User.USER_NODE_SLACK_ID] = self.slack_id if self.slack_id else ''
         result_node[User.USER_NODE_UPDATED_AT] = self.updated_at if self.updated_at else 0
-        result_node[User.USER_NODE_TITLE] = self.title if self.title else ''
+        result_node[User.USER_NODE_ROLE_NAME] = self.role_name if self.role_name else ''
 
         if self.attrs:
             for k, v in self.attrs.items():
@@ -170,4 +170,4 @@ class User(Neo4jCsvSerializable):
                                                                   self.employee_type,
                                                                   self.is_active,
                                                                   self.updated_at,
-                                                                  self.title)
+                                                                  self.role_name)

--- a/tests/unit/models/test_table_column_usage.py
+++ b/tests/unit/models/test_table_column_usage.py
@@ -32,7 +32,7 @@ class TestTableColumnUsage(unittest.TestCase):
                      'github_username': '',
                      'team_name': '',
                      'email': 'john@example.com',
-                     'title': ''}]
+                     'role_name': ''}]
         self.assertEqual(expected, actual)
 
         rel_row = table_col_usage.next_relation()

--- a/tests/unit/models/test_user.py
+++ b/tests/unit/models/test_user.py
@@ -22,7 +22,7 @@ class TestUser(unittest.TestCase):
                          slack_id='slack',
                          is_active=True,
                          updated_at=1,
-                         title='swe')
+                         role_name='swe')
 
     def test_get_user_model_key(self):
         # type: () -> None
@@ -46,13 +46,11 @@ class TestUser(unittest.TestCase):
                          slack_id='slack',
                          is_active=True,
                          updated_at=1,
-                         title='swe',
-                         role='SWE',
+                         role_name='swe',
                          enable_notify=True)
         nodes = test_user.create_nodes()
         self.assertEqual(nodes[0]['email'], 'test@email.com')
-        self.assertEqual(nodes[0]['role'], 'SWE')
-        self.assertEqual(nodes[0]['title'], 'swe')
+        self.assertEqual(nodes[0]['role_name'], 'swe')
         self.assertTrue(nodes[0]['enable_notify'])
 
     def test_create_relation(self):


### PR DESCRIPTION
Frontend seems to name this field as `role_name`. Despite our user endpoint uses title, we will stick with role_name instead to avoid the conversion.