### PR TITLE
Remove hard-coded cluster fromt the Application model

### DIFF
--- a/databuilder/models/application.py
+++ b/databuilder/models/application.py
@@ -29,6 +29,7 @@ class Application(Neo4jCsvSerializable):
                  dag_id,  # type: str,
                  application_url_template,  # type: str
                  db_name='hive',  # type: str
+                 cluster='gold', # type: str
                  schema='',  # type: str
                  table_name='',  # type: str
                  exec_date='',  # type: str
@@ -38,7 +39,7 @@ class Application(Neo4jCsvSerializable):
 
         # todo: need to modify this hack
         self.application_url = application_url_template.format(dag_id=dag_id)
-        self.database, self.schema, self.table = db_name, schema, table_name
+        self.database, self.cluster, self.schema, self.table = db_name, cluster, schema, table_name
 
         self.dag = dag_id
 
@@ -66,12 +67,12 @@ class Application(Neo4jCsvSerializable):
         return TableMetadata.TABLE_KEY_FORMAT.format(db=self.database,
                                                      schema=self.schema,
                                                      tbl=self.table,
-                                                     cluster='gold')
+                                                     cluster=self.cluster)
 
     def get_application_model_key(self):
         # type: (...) -> str
         # returns formatting string for application of type dag
-        return Application.APPLICATION_KEY_FORMAT.format(cluster='gold',
+        return Application.APPLICATION_KEY_FORMAT.format(cluster=self.cluster,
                                                          dag=self.dag,
                                                          task=self.task)
 


### PR DESCRIPTION
I was unable to get Airflow databuilder loads working for my own tables, but was able to load them with the sample loader script.  I realized that the sample loader is always defaulting to the "gold" cluster, and so was databuilder, but my own tables were in a different cluster.  This removed the hard-coded cluster and makes it an option.

More discussion at https://amundsenworkspace.slack.com/archives/CHQERT0D7/p1588011296187400

### Summary of Changes

_Include a summary of changes then remove this line_

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
