### PR TITLE
Support unicode for file system neo4j csv loader in py3

### DIFF
--- a/databuilder/loader/file_system_neo4j_csv_loader.py
+++ b/databuilder/loader/file_system_neo4j_csv_loader.py
@@ -166,20 +166,22 @@ class FsNeo4jCSVLoader(Loader):
             return writer
 
         LOGGER.info('Creating file for {}'.format(key))
-        file_out = open('{}/{}.csv'.format(dir_path, file_suffix), 'w')
+
+        if six.PY2:
+
+            file_out = open('{}/{}.csv'.format(dir_path, file_suffix), 'w')
+            writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
+                                    quoting=csv.QUOTE_NONNUMERIC, encoding='utf-8')
+        else:
+            file_out = open('{}/{}.csv'.format(dir_path, file_suffix), 'w', encoding='utf8')
+            writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
+                                    quoting=csv.QUOTE_NONNUMERIC)
 
         def file_out_close():
             # type: () -> None
             LOGGER.info('Closing file IO {}'.format(file_out))
             file_out.close()
         self._closer.register(file_out_close)
-
-        if six.PY2:
-            writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
-                                    quoting=csv.QUOTE_NONNUMERIC, encoding='utf-8')
-        else:
-            writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
-                                    quoting=csv.QUOTE_NONNUMERIC)
 
         writer.writeheader()
         file_mapping[key] = writer

--- a/databuilder/loader/file_system_neo4j_csv_loader.py
+++ b/databuilder/loader/file_system_neo4j_csv_loader.py
@@ -174,12 +174,8 @@ class FsNeo4jCSVLoader(Loader):
             file_out.close()
         self._closer.register(file_out_close)
 
-        if six.PY2:
-            writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
-                                    quoting=csv.QUOTE_NONNUMERIC, encoding='utf-8')
-        else:
-            writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
-                                    quoting=csv.QUOTE_NONNUMERIC)
+        writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
+                                quoting=csv.QUOTE_NONNUMERIC, encoding='utf-8')
 
         writer.writeheader()
         file_mapping[key] = writer

--- a/databuilder/loader/file_system_neo4j_csv_loader.py
+++ b/databuilder/loader/file_system_neo4j_csv_loader.py
@@ -174,8 +174,12 @@ class FsNeo4jCSVLoader(Loader):
             file_out.close()
         self._closer.register(file_out_close)
 
-        writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
-                                quoting=csv.QUOTE_NONNUMERIC, encoding='utf-8')
+        if six.PY2:
+            writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
+                                    quoting=csv.QUOTE_NONNUMERIC, encoding='utf-8')
+        else:
+            writer = csv.DictWriter(file_out, fieldnames=csv_record_dict.keys(),
+                                    quoting=csv.QUOTE_NONNUMERIC)
 
         writer.writeheader()
         file_mapping[key] = writer

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '2.5.12'
+__version__ = '2.5.11'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '2.5.11'
+__version__ = '2.5.12'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
### Summary of Changes

Fix `UnicodeEncodeError: 'ascii' codec can't encode character '\x91' in position 147: ordinal not in range(128)` when the csv loader used in py3.

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
