### PR TITLE
Compatibility with Neo4J 4.0.4 (4.x in general should work)

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,11 +351,12 @@ An extractor that basically get current timestamp and passes it GenericExtractor
 An extractor that extracts records from Neo4j based on provided [Cypher query](https://neo4j.com/developer/cypher/ "Cypher query"). One example is to extract data from Neo4j so that it can transform and publish to Elasticsearch.
 ```python
 job_config = ConfigFactory.from_dict({
-	'extractor.neo4j.{}'.format(Neo4jExtractor.CYPHER_QUERY_CONFIG_KEY)': cypher_query,
+	'extractor.neo4j.{}'.format(Neo4jExtractor.CYPHER_QUERY_CONFIG_KEY): cypher_query,
 	'extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): neo4j_endpoint,
 	'extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY): 'package.module.class_name',
 	'extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER): neo4j_user,
-	'extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): neo4j_password})
+	'extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): neo4j_password},
+	'extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_ENCRYPTED): True})
 job = DefaultJob(
 	conf=job_config,
 	task=DefaultTask(
@@ -370,7 +371,8 @@ job_config = ConfigFactory.from_dict({
 	'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.GRAPH_URL_CONFIG_KEY): neo4j_endpoint,
 	'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.MODEL_CLASS_CONFIG_KEY): 'databuilder.models.neo4j_data.Neo4jDataResult',
 	'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_USER): neo4j_user,
-	'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): neo4j_password})
+	'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW): neo4j_password},
+	'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_ENCRYPTED): False})
 job = DefaultJob(
 	conf=job_config,
 	task=DefaultTask(
@@ -444,6 +446,7 @@ job_config = ConfigFactory.from_dict({
 	'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY): neo4j_endpoint,
 	'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER): neo4j_user,
 	'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD): neo4j_password,
+	'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_ENCRYPTED): True,
 	'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_CREATE_ONLY_NODES): [DESCRIPTION_NODE_LABEL],
 	'publisher.neo4j.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG): job_publish_tag
 })
@@ -698,7 +701,8 @@ job_config = ConfigFactory.from_dict({
 	'publisher.neo4j.{}'.format(neo4j_csv_publisher.RELATION_FILES_DIR): relationship_files_folder,
 	'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_END_POINT_KEY): neo4j_endpoint,
 	'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_USER): neo4j_user,
-	'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD): neo4j_password,})
+	'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_PASSWORD): neo4j_password,
+	'publisher.neo4j.{}'.format(neo4j_csv_publisher.NEO4J_ENCRYPTED): True})
 
 job = DefaultJob(
 	conf=job_config,

--- a/databuilder/extractor/neo4j_extractor.py
+++ b/databuilder/extractor/neo4j_extractor.py
@@ -20,6 +20,8 @@ class Neo4jExtractor(Extractor):
     NEO4J_AUTH_USER = 'neo4j_auth_user'
     NEO4J_AUTH_PW = 'neo4j_auth_pw'
     NEO4J_MAX_CONN_LIFE_TIME_SEC = 'neo4j_max_conn_life_time_sec'
+    NEO4J_ENCRYPTED = 'neo4j_encrypted'
+    """NEO4J_ENCRYPTED is a boolean indicating whether to use SSL/TLS when connecting."""
 
     DEFAULT_CONFIG = ConfigFactory.from_dict({NEO4J_MAX_CONN_LIFE_TIME_SEC: 50, })
 
@@ -61,7 +63,8 @@ class Neo4jExtractor(Extractor):
                                     max_connection_life_time=self.conf.get_int(
                                         Neo4jExtractor.NEO4J_MAX_CONN_LIFE_TIME_SEC),
                                     auth=(self.conf.get_string(Neo4jExtractor.NEO4J_AUTH_USER),
-                                          self.conf.get_string(Neo4jExtractor.NEO4J_AUTH_PW)))
+                                          self.conf.get_string(Neo4jExtractor.NEO4J_AUTH_PW)),
+                                    encrypted=self.conf.get_bool(Neo4jExtractor.NEO4J_ENCRYPTED))
 
     def _execute_query(self, tx):
         # type: (Any) -> Any

--- a/databuilder/extractor/neo4j_extractor.py
+++ b/databuilder/extractor/neo4j_extractor.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, Iterator, Union  # noqa: F401
 
 from pyhocon import ConfigTree, ConfigFactory  # noqa: F401
-from neo4j.v1 import GraphDatabase
+from neo4j import GraphDatabase
 
 from databuilder.extractor.base_extractor import Extractor
 
@@ -23,7 +23,7 @@ class Neo4jExtractor(Extractor):
     NEO4J_ENCRYPTED = 'neo4j_encrypted'
     """NEO4J_ENCRYPTED is a boolean indicating whether to use SSL/TLS when connecting."""
 
-    DEFAULT_CONFIG = ConfigFactory.from_dict({NEO4J_MAX_CONN_LIFE_TIME_SEC: 50, })
+    DEFAULT_CONFIG = ConfigFactory.from_dict({NEO4J_MAX_CONN_LIFE_TIME_SEC: 50, NEO4J_ENCRYPTED: True})
 
     def init(self, conf):
         # type: (ConfigTree) -> None

--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -9,7 +9,7 @@ from os.path import isfile, join
 from string import Template
 
 import six
-from neo4j.v1 import GraphDatabase, Transaction  # noqa: F401
+from neo4j import GraphDatabase, Transaction  # noqa: F401
 from neo4j.exceptions import CypherError
 from pyhocon import ConfigFactory  # noqa: F401
 from pyhocon import ConfigTree  # noqa: F401
@@ -91,6 +91,7 @@ DEFAULT_CONFIG = ConfigFactory.from_dict({NEO4J_TRANSCATION_SIZE: 500,
                                           NEO4J_PROGRESS_REPORT_FREQUENCY: 500,
                                           NEO4J_RELATIONSHIP_CREATION_CONFIRM: False,
                                           NEO4J_MAX_CONN_LIFE_TIME_SEC: 50,
+                                          NEO4J_ENCRYPTED: True,
                                           RELATION_PREPROCESSOR: NoopRelationPreprocessor()})
 
 NODE_MERGE_TEMPLATE = Template("""MERGE (node:$LABEL {key: '${KEY}'})

--- a/databuilder/task/neo4j_staleness_removal_task.py
+++ b/databuilder/task/neo4j_staleness_removal_task.py
@@ -3,6 +3,7 @@ import textwrap
 import time
 
 from neo4j import GraphDatabase  # noqa: F401
+import neo4j
 from pyhocon import ConfigFactory  # noqa: F401
 from pyhocon import ConfigTree  # noqa: F401
 from typing import Dict, Iterable, Any  # noqa: F401
@@ -18,6 +19,8 @@ NEO4J_USER = 'neo4j_user'
 NEO4J_PASSWORD = 'neo4j_password'
 NEO4J_ENCRYPTED = 'neo4j_encrypted'
 """NEO4J_ENCRYPTED is a boolean indicating whether to use SSL/TLS when connecting."""
+NEO4J_VALIDATE_SSL = 'neo4j_validate_ssl'
+"""NEO4J_VALIDATE_SSL is a boolean indicating whether to validate the server's SSL/TLS cert against system CAs."""
 
 TARGET_NODES = "target_nodes"
 TARGET_RELATIONS = "target_relations"
@@ -34,6 +37,7 @@ MIN_MS_TO_EXPIRE = "minimum_milliseconds_to_expire"
 DEFAULT_CONFIG = ConfigFactory.from_dict({BATCH_SIZE: 100,
                                           NEO4J_MAX_CONN_LIFE_TIME_SEC: 50,
                                           NEO4J_ENCRYPTED: True,
+                                          NEO4J_VALIDATE_SSL: False,
                                           STALENESS_MAX_PCT: 5,
                                           TARGET_NODES: [],
                                           TARGET_RELATIONS: [],
@@ -88,11 +92,14 @@ class Neo4jStalenessRemovalTask(Task):
         else:
             self.marker = conf.get_string(JOB_PUBLISH_TAG)
 
+        trust = neo4j.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES if conf.get_bool(NEO4J_VALIDATE_SSL) \
+            else neo4j.TRUST_ALL_CERTIFICATES
         self._driver = \
             GraphDatabase.driver(conf.get_string(NEO4J_END_POINT_KEY),
                                  max_connection_life_time=conf.get_int(NEO4J_MAX_CONN_LIFE_TIME_SEC),
                                  auth=(conf.get_string(NEO4J_USER), conf.get_string(NEO4J_PASSWORD)),
-                                 encrypted=conf.get_bool(NEO4J_ENCRYPTED))
+                                 encrypted=conf.get_bool(NEO4J_ENCRYPTED),
+                                 trust=trust)
 
     def run(self):
         # type: () -> None

--- a/databuilder/task/neo4j_staleness_removal_task.py
+++ b/databuilder/task/neo4j_staleness_removal_task.py
@@ -33,6 +33,7 @@ MIN_MS_TO_EXPIRE = "minimum_milliseconds_to_expire"
 
 DEFAULT_CONFIG = ConfigFactory.from_dict({BATCH_SIZE: 100,
                                           NEO4J_MAX_CONN_LIFE_TIME_SEC: 50,
+                                          NEO4J_ENCRYPTED: True,
                                           STALENESS_MAX_PCT: 5,
                                           TARGET_NODES: [],
                                           TARGET_RELATIONS: [],

--- a/databuilder/task/neo4j_staleness_removal_task.py
+++ b/databuilder/task/neo4j_staleness_removal_task.py
@@ -16,6 +16,8 @@ NEO4J_END_POINT_KEY = 'neo4j_endpoint'
 NEO4J_MAX_CONN_LIFE_TIME_SEC = 'neo4j_max_conn_life_time_sec'
 NEO4J_USER = 'neo4j_user'
 NEO4J_PASSWORD = 'neo4j_password'
+NEO4J_ENCRYPTED = 'neo4j_encrypted'
+"""NEO4J_ENCRYPTED is a boolean indicating whether to use SSL/TLS when connecting."""
 
 TARGET_NODES = "target_nodes"
 TARGET_RELATIONS = "target_relations"
@@ -88,7 +90,8 @@ class Neo4jStalenessRemovalTask(Task):
         self._driver = \
             GraphDatabase.driver(conf.get_string(NEO4J_END_POINT_KEY),
                                  max_connection_life_time=conf.get_int(NEO4J_MAX_CONN_LIFE_TIME_SEC),
-                                 auth=(conf.get_string(NEO4J_USER), conf.get_string(NEO4J_PASSWORD)))
+                                 auth=(conf.get_string(NEO4J_USER), conf.get_string(NEO4J_PASSWORD)),
+                                 encrypted=conf.get_bool(NEO4J_ENCRYPTED))
 
     def run(self):
         # type: () -> None

--- a/docs/dashboard_ingestion_guide.md
+++ b/docs/dashboard_ingestion_guide.md
@@ -78,6 +78,8 @@ job_config = ConfigFactory.from_dict({
         neo4j_user,
     'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_AUTH_PW):
         neo4j_password,
+    'extractor.search_data.extractor.neo4j.{}'.format(Neo4jExtractor.NEO4J_ENCRYPTED):
+        False,
     'extractor.search_data.{}'.format(Neo4jSearchDataExtractor.CYPHER_QUERY_CONFIG_KEY):
         Neo4jSearchDataExtractor.DEFAULT_NEO4J_DASHBOARD_CYPHER_QUERY,
     'extractor.search_data.{}'.format(neo4j_csv_publisher.JOB_PUBLISH_TAG):

--- a/example/scripts/sample_data_loader.py
+++ b/example/scripts/sample_data_loader.py
@@ -92,6 +92,7 @@ def run_csv_job(file_loc, table_name, model):
         'publisher.neo4j.neo4j_endpoint': neo4j_endpoint,
         'publisher.neo4j.neo4j_user': neo4j_user,
         'publisher.neo4j.neo4j_password': neo4j_password,
+        'publisher.neo4j.neo4j_encrypted': False,
         'publisher.neo4j.job_publish_tag': 'unique_tag',  # should use unique tag here like {ds}
     })
 
@@ -120,6 +121,7 @@ def run_table_column_job(table_path, column_path):
         'publisher.neo4j.neo4j_endpoint': neo4j_endpoint,
         'publisher.neo4j.neo4j_user': neo4j_user,
         'publisher.neo4j.neo4j_password': neo4j_password,
+        'publisher.neo4j.neo4j_encrypted': False,
         'publisher.neo4j.job_publish_tag': 'unique_tag',  # should use unique tag here like {ds}
     })
     job = DefaultJob(conf=job_config,
@@ -148,6 +150,7 @@ def create_last_updated_job():
         'publisher.neo4j.neo4j_endpoint': neo4j_endpoint,
         'publisher.neo4j.neo4j_user': neo4j_user,
         'publisher.neo4j.neo4j_password': neo4j_password,
+        'publisher.neo4j.neo4j_encrypted': False,
         'publisher.neo4j.job_publish_tag': 'unique_lastupdated_tag',  # should use unique tag here like {ds}
     })
 
@@ -189,6 +192,7 @@ def create_es_publisher_sample_job(elasticsearch_index_alias='table_search_index
         'extractor.search_data.extractor.neo4j.model_class': model_name,
         'extractor.search_data.extractor.neo4j.neo4j_auth_user': neo4j_user,
         'extractor.search_data.extractor.neo4j.neo4j_auth_pw': neo4j_password,
+        'extractor.search_data.extractor.neo4j.neo4j_encrypted': False,
         'loader.filesystem.elasticsearch.file_path': extracted_search_data_path,
         'loader.filesystem.elasticsearch.mode': 'w',
         'publisher.elasticsearch.file_path': extracted_search_data_path,

--- a/tests/unit/publisher/test_neo4j_csv_publisher.py
+++ b/tests/unit/publisher/test_neo4j_csv_publisher.py
@@ -4,7 +4,7 @@ import unittest
 import uuid
 
 from mock import patch, MagicMock
-from neo4j.v1 import GraphDatabase
+from neo4j import GraphDatabase
 from pyhocon import ConfigFactory
 
 from databuilder.publisher import neo4j_csv_publisher

--- a/tests/unit/task/test_neo4j_staleness_removal_task.py
+++ b/tests/unit/task/test_neo4j_staleness_removal_task.py
@@ -6,7 +6,7 @@ import textwrap
 import unittest
 
 from mock import patch
-from neo4j.v1 import GraphDatabase
+from neo4j import GraphDatabase
 from pyhocon import ConfigFactory
 
 from databuilder.publisher import neo4j_csv_publisher


### PR DESCRIPTION
### Summary of Changes

Starting with Neo4J v4, it no longer auto generates SSL/TLS
certificates if they aren't supplied. To keep the example
working, I needed config to specify whether the connection
to Neo4J should be encrypted or not.

~It defaults to False, at the moment, so I think most
people would need to add an explicit True to their config.~
The previous behavior was to assume encryption, so the default in this commit is also to assume encryption. (I had changed the default in this PR from False to True in a later commit after opening the PR.)

There are complimentary changes to `amundsenmetadatalibrary` and `amundsen` that I will put in to other PRs:
* https://github.com/lyft/amundsenmetadatalibrary/pull/139
* For amundsen, I'll wait to raise the PR until a tagged docker image of `amundsenmetadatalibrary` is in dockerhub.

~There are 10 tests that fail during `make test` that seem to require dependencies that are not in the requirements.txt. The missing modules are `google`, `cassandra`, `boto3`, `confluent_kafka`, and `requests`. Hopefully that's ok? Is there another way to express that these are needed for tests?~ The travis build failure, and then looking at `.travis.yml` made it clear what the extra install requirements were.

### Tests

I didn't see a way to change the existing tests in `tests/unit/publishers/test_neo4j_csv_publisher.py` that would check the value of the new encrypted config parameter. I also didn't see an existing test that covered the `_try_create_index` function directly. I didn't feel confident to introduce tests at a level of abstraction where there aren't already existing tests (i.e. testing a _private method.)

### Documentation

I added the new `NEO4J_ENCRYPTED` config key to the examples in `README.md`. I've also added docstrings to wherever the `NEO4J_ENCRYPTED` attribute is defined.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
