### PR TITLE
fix: Cast int on last_successful_run_timestamp on Dashboard search extraction

### DIFF
--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -90,7 +90,7 @@ class Neo4jSearchDataExtractor(Extractor):
         coalesce(db_descr.description, '') as description,
         coalesce(dbg.description, '') as group_description, dbg.dashboard_group_url as group_url,
         db.dashboard_url as url, db.key as uri,
-        'mode' as product, last_exec.timestamp as last_successful_run_timestamp,
+        'mode' as product, toInt(last_exec.timestamp) as last_successful_run_timestamp,
         COLLECT(DISTINCT query.name) as query_names,
         total_usage
         order by dbg.name

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '2.5.16'
+__version__ = '2.5.17'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
### Summary of Changes

Previously, `last_successful_run_timestamp` was empty string when missing ends up failing in search service. Fixing the extraction query to cast it to Int and it will return `None` when missing and it's proper behavior.

### Tests

Integration test.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
