### PR TITLE
fix: revert default search mapping change

### DIFF
--- a/databuilder/publisher/elasticsearch_constants.py
+++ b/databuilder/publisher/elasticsearch_constants.py
@@ -16,7 +16,6 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
             "name": {
               "type":"text",
               "analyzer": "simple",
-              "search_analyzer": "whitespace",
               "fields": {
                 "raw": {
                   "type": "keyword"
@@ -26,7 +25,6 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
             "schema": {
               "type":"text",
               "analyzer": "simple",
-              "search_analyzer": "whitespace",
               "fields": {
                 "raw": {
                   "type": "keyword"
@@ -42,12 +40,11 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
             },
             "description": {
               "type": "text",
-              "analyzer": "simple",
-              "search_analyzer": "whitespace",
+              "analyzer": "simple"
             },
             "column_names": {
               "type":"text",
-              "analyzer": "whitespace",
+              "analyzer": "simple",
               "fields": {
                 "raw": {
                   "type": "keyword"
@@ -56,8 +53,7 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
             },
             "column_descriptions": {
               "type": "text",
-              "analyzer": "simple",
-              "search_analyzer": "whitespace",
+              "analyzer": "simple"
             },
             "tags": {
               "type": "keyword"
@@ -70,7 +66,7 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
             },
             "database": {
               "type": "text",
-              "analyzer": "whitespace",
+              "analyzer": "simple",
               "fields": {
                 "raw": {
                   "type": "keyword"

--- a/databuilder/publisher/elasticsearch_constants.py
+++ b/databuilder/publisher/elasticsearch_constants.py
@@ -43,7 +43,7 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
             "description": {
               "type": "text",
               "analyzer": "simple",
-              "search_analyzer": "whitespace"
+              "search_analyzer": "whitespace",
             },
             "column_names": {
               "type":"text",
@@ -57,7 +57,7 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
             "column_descriptions": {
               "type": "text",
               "analyzer": "simple",
-              "search_analyzer": "whitespace"
+              "search_analyzer": "whitespace",
             },
             "tags": {
               "type": "keyword"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = '2.5.18'
+__version__ = '2.5.19'
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
 with open(requirements_path) as requirements_file:


### PR DESCRIPTION
### Summary of Changes

So the change got more pushed back internally.  Let's revert it for now.

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
