### PR TITLE
fix: Added role_name to defaut user query in Neo4jSearchDataExtractor

### DIFF
--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -71,7 +71,7 @@ class Neo4jSearchDataExtractor(Extractor):
         return user.email as email, user.first_name as first_name, user.last_name as last_name,
         user.full_name as full_name, user.github_username as github_username, user.team_name as team_name,
         user.employee_type as employee_type, manager.email as manager_email,
-        user.slack_id as slack_id, user.is_active as is_active,
+        user.slack_id as slack_id, user.is_active as is_active, user.role_name as role_name,
         REDUCE(sum_r = 0, r in COLLECT(DISTINCT read)| sum_r + r.read_count) AS total_read,
         count(distinct b) as total_own,
         count(distinct c) AS total_follow


### PR DESCRIPTION
### Summary of Changes

Added `role_name` to `Neo4jSearchDataExtractor.DEFAULT_NEO4J_USER_CYPHER_QUERY`.

This field was added to the ES document in #232, but it was not added to the default query in the `Neo4jSearchDataExtractor`. Consequently, attempts to use the default query would fail.

This change renders it unnecessary to hardcode the user query for a basic Neo4j to ElasticSearch load, as in `sample_data_loader.py`.

### Tests

N/A: Just a string change in `Neo4jSearchDataExtractor`. `sample_data_loader.py` has no unit tests, but manually running works as expected.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
