### PR TITLE
feat: Add a transformer that adds tags to all tables created in a job

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,17 +638,19 @@ job.launch()
 ```
 
 #### [TemplateVariableSubstitutionTransformer](./databuilder/transformer/template_variable_substitution_transformer.py)
-Adds or replaces field in Dict by string.format based on given template and provide record Dict as a template parameter
+Adds or replaces field in Dict by string.format based on given template and provide record Dict as a template parameter.
 
 #### [DictToModel](./databuilder/transformer/dict_to_model.py)
-Transforms dictionary into model
+Transforms dictionary into model.
 
 #### [TimestampStringToEpoch](./databuilder/transformer/timestamp_string_to_epoch.py)
-Transforms string timestamp into int epoch
+Transforms string timestamp into int epoch.
 
 #### [RemoveFieldTransformer](./databuilder/transformer/remove_field_transformer.py)
 Remove fields from the Dict.
 
+#### [TableTagTransformer](./databuilder/transformer/table_tag_transformer.py)
+Adds the same set of tags to all tables produced by the job.
 
 ## List of loader
 #### [FsNeo4jCSVLoader](https://github.com/lyft/amundsendatabuilder/blob/master/databuilder/loader/file_system_neo4j_csv_loader.py "FsNeo4jCSVLoader")

--- a/databuilder/extractor/neo4j_search_data_extractor.py
+++ b/databuilder/extractor/neo4j_search_data_extractor.py
@@ -79,7 +79,6 @@ class Neo4jSearchDataExtractor(Extractor):
         """
     )
 
-    # todo: 1. change mode to generic once add more support for dashboard
     DEFAULT_NEO4J_DASHBOARD_CYPHER_QUERY = textwrap.dedent(
         """
         MATCH (db:Dashboard)
@@ -96,7 +95,7 @@ class Neo4jSearchDataExtractor(Extractor):
         coalesce(db_descr.description, '') as description,
         coalesce(dbg.description, '') as group_description, dbg.dashboard_group_url as group_url,
         db.dashboard_url as url, db.key as uri,
-        'mode' as product, toInt(last_exec.timestamp) as last_successful_run_timestamp,
+        split(db.key, '_')[0] as product, toInt(last_exec.timestamp) as last_successful_run_timestamp,
         COLLECT(DISTINCT query.name) as query_names,
         total_usage
         order by dbg.name

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -260,11 +260,8 @@ class TableMetadata(Neo4jCsvSerializable):
         self.columns = columns if columns else []
         self.is_view = is_view
         self.attrs = None
-        if isinstance(tags, str):
-            tags = list(filter(None, tags.split(',')))
-        if isinstance(tags, list):
-            tags = [tag.lower().strip() for tag in tags]
-        self.tags = tags
+
+        self.tags = TableMetadata.format_tags(tags)
 
         if kwargs:
             self.attrs = copy.deepcopy(kwargs)
@@ -330,6 +327,14 @@ class TableMetadata(Neo4jCsvSerializable):
                                                                tbl=self.name,
                                                                col=col.name,
                                                                description_id=description.get_description_id())
+
+    @staticmethod
+    def format_tags(tags):
+        if isinstance(tags, str):
+            tags = list(filter(None, tags.split(',')))
+        if isinstance(tags, list):
+            tags = [tag.lower().strip() for tag in tags]
+        return tags
 
     def create_next_node(self):
         # type: () -> Union[Dict[str, Any], None]

--- a/databuilder/models/table_metadata.py
+++ b/databuilder/models/table_metadata.py
@@ -1,5 +1,6 @@
 import copy
 from collections import namedtuple
+from six import string_types
 
 from typing import Iterable, Any, Union, Iterator, Dict, Set  # noqa: F401
 
@@ -330,7 +331,7 @@ class TableMetadata(Neo4jCsvSerializable):
 
     @staticmethod
     def format_tags(tags):
-        if isinstance(tags, str):
+        if isinstance(tags, string_types):
             tags = list(filter(None, tags.split(',')))
         if isinstance(tags, list):
             tags = [tag.lower().strip() for tag in tags]

--- a/databuilder/transformer/table_tag_transformer.py
+++ b/databuilder/transformer/table_tag_transformer.py
@@ -14,18 +14,17 @@ class TableTagTransformer(Transformer):
         conf = conf.with_fallback(TableTagTransformer.DEFAULT_CONFIG)
         tags = conf.get_string(TableTagTransformer.TAGS)
 
-        if isinstance(tags, str):
-            tags = tags.split(",")
-        self.tags = tags
+        self.tags = TableMetadata.format_tags(tags)
 
     def transform(self, record):
         if isinstance(record, TableMetadata):
             if record.tags:
+                print(record.tags)
                 record.tags += self.tags
             else:
                 record.tags = self.tags
-            return record
+        return record
 
     def get_scope(self):
         # type: () -> str
-        return "transformer.tabletag"
+        return "transformer.table_tag"

--- a/databuilder/transformer/table_tag_transformer.py
+++ b/databuilder/transformer/table_tag_transformer.py
@@ -19,7 +19,6 @@ class TableTagTransformer(Transformer):
     def transform(self, record):
         if isinstance(record, TableMetadata):
             if record.tags:
-                print(record.tags)
                 record.tags += self.tags
             else:
                 record.tags = self.tags

--- a/databuilder/transformer/table_tag_transformer.py
+++ b/databuilder/transformer/table_tag_transformer.py
@@ -17,7 +17,6 @@ class TableTagTransformer(Transformer):
         if isinstance(tags, str):
             tags = tags.split(",")
         self.tags = tags
-        print("\n\n\n***** SETTING UP TABLES WITH TAGS {}".format(self.tags))
 
     def transform(self, record):
         if isinstance(record, TableMetadata):

--- a/databuilder/transformer/table_tag_transformer.py
+++ b/databuilder/transformer/table_tag_transformer.py
@@ -7,7 +7,7 @@ from databuilder.models.table_metadata import TableMetadata
 class TableTagTransformer(Transformer):
     """Simple transformer that adds tags to all table nodes produced as part of a job."""
     # Config
-    TAGS = "tags"
+    TAGS = 'tags'
     DEFAULT_CONFIG = ConfigFactory.from_dict({TAGS: None})
 
     def init(self, conf):
@@ -26,4 +26,4 @@ class TableTagTransformer(Transformer):
 
     def get_scope(self):
         # type: () -> str
-        return "transformer.table_tag"
+        return 'transformer.table_tag'

--- a/databuilder/transformer/table_tag_transformer.py
+++ b/databuilder/transformer/table_tag_transformer.py
@@ -1,0 +1,26 @@
+class TableTagTransformer(Transformer):
+    """Simple transformer that adds tags to all table nodes produced as part of a job."""
+    # Config
+    TAGS = "tags"
+    DEFAULT_CONFIG = ConfigFactory.from_dict({TAGS: None})
+
+    def init(self, conf):
+        conf = conf.with_fallback(TableTagTransformer.DEFAULT_CONFIG)
+        tags = conf.get_string(TableTagTransformer.TAGS)
+
+        if isinstance(tags, str):
+            tags = tags.split(",")
+        self.tags = tags
+        print("\n\n\n***** SETTING UP TABLES WITH TAGS {}".format(self.tags))
+
+    def transform(self, record):
+        if isinstance(record, TableMetadata):
+            if record.tags:
+                record.tags += self.tags
+            else:
+                record.tags = self.tags
+            return record
+
+    def get_scope(self):
+        # type: () -> str
+        return "transformer.tabletag"

--- a/databuilder/transformer/table_tag_transformer.py
+++ b/databuilder/transformer/table_tag_transformer.py
@@ -1,7 +1,7 @@
+from pyhocon import ConfigFactory
+
 from databuilder.transformer.base_transformer import Transformer
 from databuilder.models.table_metadata import TableMetadata
-
-from pyhocon import ConfigFactory
 
 
 class TableTagTransformer(Transformer):

--- a/databuilder/transformer/table_tag_transformer.py
+++ b/databuilder/transformer/table_tag_transformer.py
@@ -1,3 +1,9 @@
+from databuilder.transformer.base_transformer import Transformer
+from databuilder.models.table_metadata import TableMetadata
+
+from pyhocon import ConfigFactory
+
+
 class TableTagTransformer(Transformer):
     """Simple transformer that adds tags to all table nodes produced as part of a job."""
     # Config

--- a/tests/unit/transformer/test_table_tag_transformer.py
+++ b/tests/unit/transformer/test_table_tag_transformer.py
@@ -1,0 +1,78 @@
+import unittest
+
+from pyhocon import ConfigFactory
+
+from databuilder.transformer.table_tag_transformer import TableTagTransformer
+from databuilder.models.table_metadata import TableMetadata, TagMetadata
+
+
+class TestTableTagTransformer(unittest.TestCase):
+
+    def test_single_tag(self):
+        # type: () -> None
+
+        transformer = TableTagTransformer()
+        config = ConfigFactory.from_dict({
+            TableTagTransformer.TAGS: "foo",
+        })
+        transformer.init(conf=config)
+
+        result = transformer.transform(TableMetadata(
+            database = "test_db",
+            cluster = "test_cluster",
+            schema = "test_schema",
+            name = "test_table",
+            description = "",
+        ))
+        
+        self.assertEqual(result.tags, ["foo"])
+
+    def test_multiple_tags_comma_delimited(self):
+        transformer = TableTagTransformer()
+        config = ConfigFactory.from_dict({
+            TableTagTransformer.TAGS: "foo,bar",
+        })
+        transformer.init(conf=config)
+
+        result = transformer.transform(TableMetadata(
+            database = "test_db",
+            cluster = "test_cluster",
+            schema = "test_schema",
+            name = "test_table",
+            description = "",
+        ))
+        
+        self.assertEqual(result.tags, ["foo", "bar"])
+
+    def test_add_tag_to_existing_tags(self):
+        transformer = TableTagTransformer()
+        config = ConfigFactory.from_dict({
+            TableTagTransformer.TAGS: "baz",
+        })
+        transformer.init(conf=config)
+
+        result = transformer.transform(TableMetadata(
+            database = "test_db",
+            cluster = "test_cluster",
+            schema = "test_schema",
+            name = "test_table",
+            description = "",
+            tags = "foo,bar",
+        ))
+        self.assertEqual(result.tags, ["foo", "bar", "baz"])
+    
+    def test_tags_not_added_to_other_objects(self):
+        transformer = TableTagTransformer()
+        config = ConfigFactory.from_dict({
+            TableTagTransformer.TAGS: "new_tag",
+        })
+        transformer.init(conf=config)
+        class NotATable():
+            tags = "existing_tag"
+        result = transformer.transform(NotATable())
+        
+        self.assertEqual(result.tags, "existing_tag")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/transformer/test_table_tag_transformer.py
+++ b/tests/unit/transformer/test_table_tag_transformer.py
@@ -10,67 +10,67 @@ class TestTableTagTransformer(unittest.TestCase):
     def test_single_tag(self):
         transformer = TableTagTransformer()
         config = ConfigFactory.from_dict({
-            TableTagTransformer.TAGS: "foo",
+            TableTagTransformer.TAGS: 'foo',
         })
         transformer.init(conf=config)
 
         result = transformer.transform(TableMetadata(
-            database="test_db",
-            cluster="test_cluster",
-            schema="test_schema",
-            name="test_table",
-            description="",
+            database='test_db',
+            cluster='test_cluster',
+            schema='test_schema',
+            name='test_table',
+            description='',
         ))
 
-        self.assertEqual(result.tags, ["foo"])
+        self.assertEqual(result.tags, ['foo'])
 
     def test_multiple_tags_comma_delimited(self):
         transformer = TableTagTransformer()
         config = ConfigFactory.from_dict({
-            TableTagTransformer.TAGS: "foo,bar",
+            TableTagTransformer.TAGS: 'foo,bar',
         })
         transformer.init(conf=config)
 
         result = transformer.transform(TableMetadata(
-            database="test_db",
-            cluster="test_cluster",
-            schema="test_schema",
-            name="test_table",
-            description="",
+            database='test_db',
+            cluster='test_cluster',
+            schema='test_schema',
+            name='test_table',
+            description='',
         ))
 
-        self.assertEqual(result.tags, ["foo", "bar"])
+        self.assertEqual(result.tags, ['foo', 'bar'])
 
     def test_add_tag_to_existing_tags(self):
         transformer = TableTagTransformer()
         config = ConfigFactory.from_dict({
-            TableTagTransformer.TAGS: "baz",
+            TableTagTransformer.TAGS: 'baz',
         })
         transformer.init(conf=config)
 
         result = transformer.transform(TableMetadata(
-            database="test_db",
-            cluster="test_cluster",
-            schema="test_schema",
-            name="test_table",
-            description="",
-            tags="foo,bar",
+            database='test_db',
+            cluster='test_cluster',
+            schema='test_schema',
+            name='test_table',
+            description='',
+            tags='foo,bar',
         ))
-        self.assertEqual(result.tags, ["foo", "bar", "baz"])
+        self.assertEqual(result.tags, ['foo', 'bar', 'baz'])
 
     def test_tags_not_added_to_other_objects(self):
         transformer = TableTagTransformer()
         config = ConfigFactory.from_dict({
-            TableTagTransformer.TAGS: "new_tag",
+            TableTagTransformer.TAGS: 'new_tag',
         })
         transformer.init(conf=config)
 
         class NotATable():
-            tags = "existing_tag"
+            tags = 'existing_tag'
 
         result = transformer.transform(NotATable())
 
-        self.assertEqual(result.tags, "existing_tag")
+        self.assertEqual(result.tags, 'existing_tag')
 
 
 if __name__ == '__main__':

--- a/tests/unit/transformer/test_table_tag_transformer.py
+++ b/tests/unit/transformer/test_table_tag_transformer.py
@@ -3,14 +3,11 @@ import unittest
 from pyhocon import ConfigFactory
 
 from databuilder.transformer.table_tag_transformer import TableTagTransformer
-from databuilder.models.table_metadata import TableMetadata, TagMetadata
+from databuilder.models.table_metadata import TableMetadata
 
 
 class TestTableTagTransformer(unittest.TestCase):
-
     def test_single_tag(self):
-        # type: () -> None
-
         transformer = TableTagTransformer()
         config = ConfigFactory.from_dict({
             TableTagTransformer.TAGS: "foo",
@@ -18,13 +15,13 @@ class TestTableTagTransformer(unittest.TestCase):
         transformer.init(conf=config)
 
         result = transformer.transform(TableMetadata(
-            database = "test_db",
-            cluster = "test_cluster",
-            schema = "test_schema",
-            name = "test_table",
-            description = "",
+            database="test_db",
+            cluster="test_cluster",
+            schema="test_schema",
+            name="test_table",
+            description="",
         ))
-        
+
         self.assertEqual(result.tags, ["foo"])
 
     def test_multiple_tags_comma_delimited(self):
@@ -35,13 +32,13 @@ class TestTableTagTransformer(unittest.TestCase):
         transformer.init(conf=config)
 
         result = transformer.transform(TableMetadata(
-            database = "test_db",
-            cluster = "test_cluster",
-            schema = "test_schema",
-            name = "test_table",
-            description = "",
+            database="test_db",
+            cluster="test_cluster",
+            schema="test_schema",
+            name="test_table",
+            description="",
         ))
-        
+
         self.assertEqual(result.tags, ["foo", "bar"])
 
     def test_add_tag_to_existing_tags(self):
@@ -52,25 +49,27 @@ class TestTableTagTransformer(unittest.TestCase):
         transformer.init(conf=config)
 
         result = transformer.transform(TableMetadata(
-            database = "test_db",
-            cluster = "test_cluster",
-            schema = "test_schema",
-            name = "test_table",
-            description = "",
-            tags = "foo,bar",
+            database="test_db",
+            cluster="test_cluster",
+            schema="test_schema",
+            name="test_table",
+            description="",
+            tags="foo,bar",
         ))
         self.assertEqual(result.tags, ["foo", "bar", "baz"])
-    
+
     def test_tags_not_added_to_other_objects(self):
         transformer = TableTagTransformer()
         config = ConfigFactory.from_dict({
             TableTagTransformer.TAGS: "new_tag",
         })
         transformer.init(conf=config)
+
         class NotATable():
             tags = "existing_tag"
+
         result = transformer.transform(NotATable())
-        
+
         self.assertEqual(result.tags, "existing_tag")
 
 


### PR DESCRIPTION
### Summary of Changes

This was a use case that came up for us several times, where we want all tables loaded from a specific source to have the same tag.  This transformer makes it easy to add a tag independent of what the extractor is doing.

### Tests
It seems like none of the other transformers have tests, so I was not sure what pattern to follow.

### Documentation

No new docs, hopefully the transformer is simple enough to be self explanatory.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
