### PR TITLE
fix: Escape backslashes properly in Neo4jCsvPublisher

### DIFF
--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -395,7 +395,7 @@ ON MATCH SET {update_prop_body}""".format(create_prop_body=create_prop_body,
             # if isinstance(str, v):
             v = v.replace('\'', "\\'")
             # escape backslash for Cypher query
-            v = v.replace("\\", "\\")
+            v = v.replace('\\', '\\\\')
 
             if k.endswith(UNQUOTED_SUFFIX):
                 k = k[:-len(UNQUOTED_SUFFIX)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pytest>=3.6.0,<4.0
 # Pytest plugin for measuring coverage.
 # License: MIT
 # Upstream url: https://github.com/pytest-dev/pytest-cov
-pytest-cov>=2.5.1,<3.0
+pytest-cov>=2.5.1,<=2.9
 
 # Rolling backport of unittest.mock for all Pythons
 # License: BSD


### PR DESCRIPTION
### Summary of Changes

This is basically a re-do of #191.

`Neo4jCsvPublisher` currently imports data by crafting Cypher queries through string building. Problems occur in string literals when the original strings contain backslashes: literal values like `\n` would be converted to a newline, while a literal that is not a valid escape sequence (e.g., `\_`) will result in an error decoding the Cypher query.

This issue was identified and addressed in #191, but the final, accepted fix doesn't actually do anything. The confusion seems to stem from the way Python outputs string literals in a REPL-like environment:

```
>>> '\\'
'\\'
>>> print('\\')
\

>>> '\_'
'\\_'
>>> '\_'.replace("\\", "\\") # the accepted fix from #191
'\\_'
>>> print('\_'.replace("\\", "\\")) # note: this didn't really work!
\_

>>> print('\_'.replace('\\', '\\\\')) # the original proposal in #191 and what is done in this PR
\\_
```

This is a quick fix to make importing more robust (any description that contains a backslash is currently an issue in some form), but I'm of the mindset that a proper solution would be to use query parameters in these import statements rather than hardcoding string literals and trying to escape any relevant sequences. (Note that there are still ways to break these queries, e.g., by including a null byte in a string. I don't know how to solve all such problems through a string builder approach.)

### Tests

n/a

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
