### PR TITLE
fix: Update pytest-cov>=2.5.1,<=2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pytest>=3.6.0,<4.0
 # Pytest plugin for measuring coverage.
 # License: MIT
 # Upstream url: https://github.com/pytest-dev/pytest-cov
-pytest-cov>=2.5.1,<3.0
+pytest-cov>=2.5.1,<=2.9
 
 # Rolling backport of unittest.mock for all Pythons
 # License: BSD


### PR DESCRIPTION
### Summary of Changes

Freeze the version of pytest-cov due to the conflict with pytest

`pytest-cov 2.10.0 has requirement pytest>=4.6, but you'll have pytest 3.10.1 which is incompatible.
`

Failing build: https://travis-ci.com/github/lyft/amundsendatabuilder/jobs/349937443


### Tests

Passes build.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
