### PR TITLE
fix: Variable organization in Mode URL

### DIFF
--- a/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
+++ b/databuilder/extractor/dashboard/mode_analytics/mode_dashboard_extractor.py
@@ -54,7 +54,7 @@ class ModeDashboardExtractor(Extractor):
         dashboard_group_url_transformer.init(
             conf=Scoped.get_scoped_conf(self._conf, dashboard_group_url_transformer.get_scope()).with_fallback(
                 ConfigFactory.from_dict({VAR_FIELD_NAME: 'dashboard_group_url',
-                                         TEMPLATE: 'https://app.mode.com/lyft/spaces/{dashboard_group_id}'})))
+                                         TEMPLATE: 'https://app.mode.com/{organization}/spaces/{dashboard_group_id}'})))
 
         transformers.append(dashboard_group_url_transformer)
 
@@ -62,7 +62,7 @@ class ModeDashboardExtractor(Extractor):
         dashboard_url_transformer.init(
             conf=Scoped.get_scoped_conf(self._conf, dashboard_url_transformer.get_scope()).with_fallback(
                 ConfigFactory.from_dict({VAR_FIELD_NAME: 'dashboard_url',
-                                         TEMPLATE: 'https://app.mode.com/lyft/reports/{dashboard_id}'})))
+                                         TEMPLATE: 'https://app.mode.com/{organization}/reports/{dashboard_id}'})))
         transformers.append(dashboard_url_transformer)
 
         dict_to_model_transformer = DictToModel()


### PR DESCRIPTION
### Summary of Changes

Change the Mode dashboard URL based on organization name passed in the config.

### Tests

None, I didn't see tests for dashboards yet.

### Documentation

None

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
