### PR TITLE
fix: Fix broken doc link to dashboard_execution model

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -191,7 +191,7 @@ A model that encapsulate Dashboard's last modified timestamp in epoch
 [ModeDashboardLastModifiedTimestampExtractor](../databuilder/extractor/dashboard/mode_analytics/mode_dashboard_last_modified_timestamp_extractor.py)   
 
 
-#### [DashboardExecution](../models/dashboard/dashboard_execution.py)
+#### [DashboardExecution](../databuilder/models/dashboard/dashboard_execution.py)
 A model that encapsulate Dashboard's execution timestamp in epoch and execution state. Note that this model supports last_execution and last_successful_execution by using [different identifier](../databuilder/models/dashboard/dashboard_execution.py#L23) in the URI.
 
 #### Extraction


### PR DESCRIPTION
### Summary of Changes

Updated the contents of `docs/models.md` and fix a malformed link to the implementation of the `dashboard_execution` model.

### Tests

None needed, only updates documentation

### Documentation

Updated the contents of `docs/models.md` and fix a malformed link to the implementation of the `dashboard_execution` model. I could not find any documentation about how to build the docs locally to test (I assume because you're using GitHub pages) but I tested on my fork and the relative link worked when I followed it through the GitHub UI, whereas it did not before.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
