### PR TITLE
fix: Escape backslashes before quotes in Neo4jCsvPublisher

### DIFF
--- a/databuilder/publisher/neo4j_csv_publisher.py
+++ b/databuilder/publisher/neo4j_csv_publisher.py
@@ -391,11 +391,11 @@ ON MATCH SET {update_prop_body}""".format(create_prop_body=create_prop_body,
                 template_params[k] = v
                 continue
 
-            # escape quote for Cypher query
             # if isinstance(str, v):
-            v = v.replace('\'', "\\'")
             # escape backslash for Cypher query
             v = v.replace('\\', '\\\\')
+            # escape quote for Cypher query
+            v = v.replace('\'', "\\'")
 
             if k.endswith(UNQUOTED_SUFFIX):
                 k = k[:-len(UNQUOTED_SUFFIX)]


### PR DESCRIPTION
### Summary of Changes

I have to come clean: I never tested the change in #291. It seemed like an obvious fix, but this is actually a regression. Any string with a single quote in it will now break the publisher. (Sorry!)

The escaping of backslashes needs to happen *before* the escaping of quotes. The reason for this is obvious (in retrospect). Consider the following:

`O'Brien` --(escape quote)--> `O\'Brien` --(escape backslash)--> `O\\'Brien`

Put this in quotes, and you get a problem: `'O\\'Brien'`

This PR changes the order so that backslashes are escaped first:

`O'Brien` --(escape backslash)--> `O'Brien` --(escape quote)--> `O\'Brien` (much better)

So now quotes should work fine again, and backslashes should actually work too (which was the point of both #191 and #291):

`c:\users\o'brien` --(escape backslash)--> `c:\\users\\o'brien` --(escape quote)--> `c:\\users\\o\'brien`


### Tests

Tested manually.

### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
