### PR TITLE
feat: allow hive sql to be provided as config

### DIFF
--- a/databuilder/extractor/hive_table_metadata_extractor.py
+++ b/databuilder/extractor/hive_table_metadata_extractor.py
@@ -70,9 +70,7 @@ class HiveTableMetadataExtractor(Extractor):
         default_sql = HiveTableMetadataExtractor.DEFAULT_SQL_STATEMENT.format(
             where_clause_suffix=conf.get_string(HiveTableMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY))
 
-        self.sql_stmt = conf.get_string(HiveTableMetadataExtractor.EXTRACT_SQL.format(
-            where_clause_suffix=conf.get_string(HiveTableMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY)
-        ), default=default_sql)
+        self.sql_stmt = conf.get_string(HiveTableMetadataExtractor.EXTRACT_SQL, default=default_sql)
 
         LOGGER.info('SQL for hive metastore: {}'.format(self.sql_stmt))
 

--- a/databuilder/extractor/hive_table_metadata_extractor.py
+++ b/databuilder/extractor/hive_table_metadata_extractor.py
@@ -23,12 +23,13 @@ class HiveTableMetadataExtractor(Extractor):
     """
     Extracts Hive table and column metadata from underlying meta store database using SQLAlchemyExtractor
     """
+    EXTRACT_SQL = 'extract_sql'
     # SELECT statement from hive metastore database to extract table and column metadata
     # Below SELECT statement uses UNION to combining two queries together.
     # 1st query is retrieving partition columns
     # 2nd query is retrieving columns
     # Using UNION to combine above two statements and order by table & partition identifier.
-    SQL_STATEMENT = """
+    DEFAULT_SQL_STATEMENT = """
     SELECT source.* FROM
     (SELECT t.TBL_ID, d.NAME as `schema`, t.TBL_NAME name, t.TBL_TYPE, tp.PARAM_VALUE as description,
            p.PKEY_NAME as col_name, p.INTEGER_IDX as col_sort_order,
@@ -66,8 +67,12 @@ class HiveTableMetadataExtractor(Extractor):
         conf = conf.with_fallback(HiveTableMetadataExtractor.DEFAULT_CONFIG)
         self._cluster = '{}'.format(conf.get_string(HiveTableMetadataExtractor.CLUSTER_KEY))
 
-        self.sql_stmt = HiveTableMetadataExtractor.SQL_STATEMENT.format(
+        default_sql = HiveTableMetadataExtractor.DEFAULT_SQL_STATEMENT.format(
             where_clause_suffix=conf.get_string(HiveTableMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY))
+
+        self.sql_stmt = conf.get_string(HiveTableMetadataExtractor.EXTRACT_SQL.format(
+            where_clause_suffix=conf.get_string(HiveTableMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY)
+        ), default=default_sql)
 
         LOGGER.info('SQL for hive metastore: {}'.format(self.sql_stmt))
 

--- a/tests/unit/extractor/test_hive_table_metadata_extractor.py
+++ b/tests/unit/extractor/test_hive_table_metadata_extractor.py
@@ -230,10 +230,10 @@ class TestHiveTableMetadataExtractorWithWhereClause(unittest.TestCase):
             extractor.init(self.conf)
             self.assertTrue(self.where_clause_suffix in extractor.sql_stmt)
 
-    def test_sql_statement_with_sql(self):
+    def test_sql_statement_with_default_sql(self):
         # type: () -> None
         """
-        Test Extraction by providing sql
+        Test Extraction by providing a default sql
         :return:
         """
         with patch.object(SQLAlchemyExtractor, '_get_connection'):

--- a/tests/unit/extractor/test_hive_table_metadata_extractor.py
+++ b/tests/unit/extractor/test_hive_table_metadata_extractor.py
@@ -230,10 +230,10 @@ class TestHiveTableMetadataExtractorWithWhereClause(unittest.TestCase):
             extractor.init(self.conf)
             self.assertTrue(self.where_clause_suffix in extractor.sql_stmt)
 
-    def test_sql_statement_with_default_sql(self):
+    def test_hive_sql_statement_with_custom_sql(self):
         # type: () -> None
         """
-        Test Extraction by providing a default sql
+        Test Extraction by providing a custom sql
         :return:
         """
         with patch.object(SQLAlchemyExtractor, '_get_connection'):

--- a/tests/unit/extractor/test_hive_table_metadata_extractor.py
+++ b/tests/unit/extractor/test_hive_table_metadata_extractor.py
@@ -230,6 +230,26 @@ class TestHiveTableMetadataExtractorWithWhereClause(unittest.TestCase):
             extractor.init(self.conf)
             self.assertTrue(self.where_clause_suffix in extractor.sql_stmt)
 
+    def test_sql_statement_with_sql(self):
+        # type: () -> None
+        """
+        Test Extraction by providing sql
+        :return:
+        """
+        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+            config_dict = {
+                HiveTableMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
+                'extractor.sqlalchemy.{}'.format(SQLAlchemyExtractor.CONN_STRING):
+                    'TEST_CONNECTION',
+                HiveTableMetadataExtractor.EXTRACT_SQL:
+                    'select sth for test {where_clause_suffix}'
+            }
+            conf = ConfigFactory.from_dict(config_dict)
+            extractor = HiveTableMetadataExtractor()
+            extractor.init(conf)
+            print (extractor.sql_stmt)
+            self.assertTrue('select sth for test' in extractor.sql_stmt)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/extractor/test_hive_table_metadata_extractor.py
+++ b/tests/unit/extractor/test_hive_table_metadata_extractor.py
@@ -247,7 +247,6 @@ class TestHiveTableMetadataExtractorWithWhereClause(unittest.TestCase):
             conf = ConfigFactory.from_dict(config_dict)
             extractor = HiveTableMetadataExtractor()
             extractor.init(conf)
-            print (extractor.sql_stmt)
             self.assertTrue('select sth for test' in extractor.sql_stmt)
 
 


### PR DESCRIPTION
### Summary of Changes

This pr is to fix https://github.com/lyft/amundsen/issues/552 which allows user to provide hive metastore sql.

### Tests

yes. add a unit test to test the new config.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
