### PR TITLE
tests: add mock for bigquery auth

### DIFF
--- a/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -137,6 +137,8 @@ class MockBigQueryClient():
         return self.tables_method
 
 
+# Patch fallback auth method to avoid actually calling google API
+@patch('google.auth.default', lambda scopes: ['dummy', 'dummy'])
 class TestBigQueryMetadataExtractor(unittest.TestCase):
     def setUp(self):
         # type: () -> None

--- a/tests/unit/extractor/test_bigquery_usage_extractor.py
+++ b/tests/unit/extractor/test_bigquery_usage_extractor.py
@@ -189,6 +189,8 @@ class MockLoggingClient():
         return self.b
 
 
+# Patch fallback auth method to avoid actually calling google API
+@patch('google.auth.default', lambda scopes: ['dummy', 'dummy'])
 class TestBigqueryUsageExtractor(unittest.TestCase):
 
     @patch('databuilder.extractor.base_bigquery_extractor.build')

--- a/tests/unit/extractor/test_bigquery_watermark_extractor.py
+++ b/tests/unit/extractor/test_bigquery_watermark_extractor.py
@@ -83,6 +83,8 @@ class MockBigQueryClient():
         return self.jobs_query
 
 
+# Patch fallback auth method to avoid actually calling google API
+@patch('google.auth.default', lambda scopes: ['dummy', 'dummy'])
 class TestBigQueryWatermarkExtractor(unittest.TestCase):
     def setUp(self):
         # type: () -> None


### PR DESCRIPTION
### Summary of Changes

Without this, tests will by default fail in a local environment because there are no Google credentials present.

Not sure why Travis was working before; if dev/CI parity is important to us, I'm happy to investigate to make it need this as well.

### Tests
n/a
### Documentation

n/a

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
